### PR TITLE
Implementa CQRS y Mediator para gestión de propiedades

### DIFF
--- a/StayWize.API/Controllers/PropertiesController.cs
+++ b/StayWize.API/Controllers/PropertiesController.cs
@@ -1,0 +1,56 @@
+﻿using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using StayWize.Application.DTOs;
+using StayWize.Application.UseCases.Properties;
+
+namespace StayWize.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class PropertiesController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public PropertiesController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var result = await _mediator.Send(new GetAllPropertiesQuery());
+        return Ok(result);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetById(Guid id)
+    {
+        var result = await _mediator.Send(new GetPropertyByIdQuery(id));
+        if (result is null) return NotFound();
+        return Ok(result);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreatePropertyDto dto)
+    {
+        var result = await _mediator.Send(new CreatePropertyCommand(dto));
+        return CreatedAtAction(nameof(GetById), new { id = result.Id }, result);
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> Update(Guid id, [FromBody] UpdatePropertyDto dto)
+    {
+        var result = await _mediator.Send(new UpdatePropertyCommand(id, dto));
+        if (!result) return NotFound();
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        var result = await _mediator.Send(new DeletePropertyCommand(id));
+        if (!result) return NotFound();
+        return NoContent();
+    }
+}

--- a/StayWize.API/Program.cs
+++ b/StayWize.API/Program.cs
@@ -1,3 +1,4 @@
+using StayWize.Application;
 using StayWize.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -6,6 +7,7 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+builder.Services.AddApplication();
 builder.Services.AddInfrastructure(builder.Configuration);
 
 var app = builder.Build();

--- a/StayWize.Application/DTOs/CreatePropertyDto.cs
+++ b/StayWize.Application/DTOs/CreatePropertyDto.cs
@@ -1,0 +1,11 @@
+﻿namespace StayWize.Application.DTOs;
+
+public class CreatePropertyDto
+{
+    public string Name { get; set; } = string.Empty;
+    public string Address { get; set; } = string.Empty;
+    public string City { get; set; } = string.Empty;
+    public string Country { get; set; } = string.Empty;
+    public int MaxGuests { get; set; }
+    public Guid OwnerId { get; set; }
+}

--- a/StayWize.Application/DTOs/PropertyDto.cs
+++ b/StayWize.Application/DTOs/PropertyDto.cs
@@ -1,0 +1,15 @@
+﻿namespace StayWize.Application.DTOs;
+
+public class PropertyDto
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Address { get; set; } = string.Empty;
+    public string City { get; set; } = string.Empty;
+    public string Country { get; set; } = string.Empty;
+    public int MaxGuests { get; set; }
+    public bool IsActive { get; set; }
+    public Guid OwnerId { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+}

--- a/StayWize.Application/DTOs/UpdatePropertyDto.cs
+++ b/StayWize.Application/DTOs/UpdatePropertyDto.cs
@@ -1,0 +1,10 @@
+﻿namespace StayWize.Application.DTOs;
+
+public class UpdatePropertyDto
+{
+    public string Name { get; set; } = string.Empty;
+    public string Address { get; set; } = string.Empty;
+    public string City { get; set; } = string.Empty;
+    public string Country { get; set; } = string.Empty;
+    public int MaxGuests { get; set; }
+}

--- a/StayWize.Application/DependencyInjection.cs
+++ b/StayWize.Application/DependencyInjection.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace StayWize.Application;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddApplication(this IServiceCollection services)
+    {
+        services.AddMediatR(cfg =>
+            cfg.RegisterServicesFromAssembly(typeof(DependencyInjection).Assembly));
+
+        return services;
+    }
+}

--- a/StayWize.Application/UseCases/Properties/CreatePropertyCommand.cs
+++ b/StayWize.Application/UseCases/Properties/CreatePropertyCommand.cs
@@ -1,0 +1,50 @@
+﻿using MediatR;
+using StayWize.Application.DTOs;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Domain.Entities;
+
+namespace StayWize.Application.UseCases.Properties;
+
+public record CreatePropertyCommand(CreatePropertyDto Dto) : IRequest<PropertyDto>;
+
+public class CreatePropertyCommandHandler
+    : IRequestHandler<CreatePropertyCommand, PropertyDto>
+{
+    private readonly IPropertyRepository _repository;
+
+    public CreatePropertyCommandHandler(IPropertyRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<PropertyDto> Handle(
+        CreatePropertyCommand request,
+        CancellationToken cancellationToken)
+    {
+        var dto = request.Dto;
+
+        var property = Property.Create(
+            dto.Name,
+            dto.Address,
+            dto.City,
+            dto.Country,
+            dto.MaxGuests,
+            dto.OwnerId);
+
+        await _repository.AddAsync(property);
+
+        return new PropertyDto
+        {
+            Id = property.Id,
+            Name = property.Name,
+            Address = property.Address,
+            City = property.City,
+            Country = property.Country,
+            MaxGuests = property.MaxGuests,
+            IsActive = property.IsActive,
+            OwnerId = property.OwnerId,
+            CreatedAt = property.CreatedAt,
+            UpdatedAt = property.UpdatedAt
+        };
+    }
+}

--- a/StayWize.Application/UseCases/Properties/DeletePropertyCommand.cs
+++ b/StayWize.Application/UseCases/Properties/DeletePropertyCommand.cs
@@ -1,0 +1,31 @@
+﻿using MediatR;
+using StayWize.Application.Common.Interfaces;
+
+namespace StayWize.Application.UseCases.Properties;
+
+public record DeletePropertyCommand(Guid Id) : IRequest<bool>;
+
+public class DeletePropertyCommandHandler
+    : IRequestHandler<DeletePropertyCommand, bool>
+{
+    private readonly IPropertyRepository _repository;
+
+    public DeletePropertyCommandHandler(IPropertyRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<bool> Handle(
+        DeletePropertyCommand request,
+        CancellationToken cancellationToken)
+    {
+        var property = await _repository.GetByIdAsync(request.Id);
+
+        if (property is null) return false;
+
+        property.SoftDelete("system");
+        await _repository.UpdateAsync(property);
+
+        return true;
+    }
+}

--- a/StayWize.Application/UseCases/Properties/GetAllPropertiesQuery.cs
+++ b/StayWize.Application/UseCases/Properties/GetAllPropertiesQuery.cs
@@ -1,0 +1,39 @@
+﻿using MediatR;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Application.DTOs;
+
+namespace StayWize.Application.UseCases.Properties;
+
+public record GetAllPropertiesQuery : IRequest<IEnumerable<PropertyDto>>;
+
+public class GetAllPropertiesQueryHandler
+    : IRequestHandler<GetAllPropertiesQuery, IEnumerable<PropertyDto>>
+{
+    private readonly IPropertyRepository _repository;
+
+    public GetAllPropertiesQueryHandler(IPropertyRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<IEnumerable<PropertyDto>> Handle(
+        GetAllPropertiesQuery request,
+        CancellationToken cancellationToken)
+    {
+        var properties = await _repository.GetAllAsync();
+
+        return properties.Select(p => new PropertyDto
+        {
+            Id = p.Id,
+            Name = p.Name,
+            Address = p.Address,
+            City = p.City,
+            Country = p.Country,
+            MaxGuests = p.MaxGuests,
+            IsActive = p.IsActive,
+            OwnerId = p.OwnerId,
+            CreatedAt = p.CreatedAt,
+            UpdatedAt = p.UpdatedAt
+        });
+    }
+}

--- a/StayWize.Application/UseCases/Properties/GetPropertyByIdQuery.cs
+++ b/StayWize.Application/UseCases/Properties/GetPropertyByIdQuery.cs
@@ -1,0 +1,41 @@
+﻿using MediatR;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Application.DTOs;
+
+namespace StayWize.Application.UseCases.Properties;
+
+public record GetPropertyByIdQuery(Guid Id) : IRequest<PropertyDto?>;
+
+public class GetPropertyByIdQueryHandler
+    : IRequestHandler<GetPropertyByIdQuery, PropertyDto?>
+{
+    private readonly IPropertyRepository _repository;
+
+    public GetPropertyByIdQueryHandler(IPropertyRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<PropertyDto?> Handle(
+        GetPropertyByIdQuery request,
+        CancellationToken cancellationToken)
+    {
+        var property = await _repository.GetByIdAsync(request.Id);
+
+        if (property is null) return null;
+
+        return new PropertyDto
+        {
+            Id = property.Id,
+            Name = property.Name,
+            Address = property.Address,
+            City = property.City,
+            Country = property.Country,
+            MaxGuests = property.MaxGuests,
+            IsActive = property.IsActive,
+            OwnerId = property.OwnerId,
+            CreatedAt = property.CreatedAt,
+            UpdatedAt = property.UpdatedAt
+        };
+    }
+}

--- a/StayWize.Application/UseCases/Properties/UpdatePropertyCommand.cs
+++ b/StayWize.Application/UseCases/Properties/UpdatePropertyCommand.cs
@@ -1,0 +1,39 @@
+﻿using MediatR;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Application.DTOs;
+
+namespace StayWize.Application.UseCases.Properties;
+
+public record UpdatePropertyCommand(Guid Id, UpdatePropertyDto Dto) : IRequest<bool>;
+
+public class UpdatePropertyCommandHandler
+    : IRequestHandler<UpdatePropertyCommand, bool>
+{
+    private readonly IPropertyRepository _repository;
+
+    public UpdatePropertyCommandHandler(IPropertyRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<bool> Handle(
+        UpdatePropertyCommand request,
+        CancellationToken cancellationToken)
+    {
+        var property = await _repository.GetByIdAsync(request.Id);
+
+        if (property is null) return false;
+
+        property.Update(
+            request.Dto.Name,
+            request.Dto.Address,
+            request.Dto.City,
+            request.Dto.Country,
+            request.Dto.MaxGuests);
+
+        property.MarkAsUpdated("system");
+        await _repository.UpdateAsync(property);
+
+        return true;
+    }
+}

--- a/StayWize.Domain/Common/BaseEntity.cs
+++ b/StayWize.Domain/Common/BaseEntity.cs
@@ -2,7 +2,7 @@
 
 namespace StayWize.Domain.Common;
 
-public abstract class BaseEntity
+public abstract class BaseEntity : ISoftDeletable
 {
     public Guid Id { get; private set; } = Uuid.NewDatabaseFriendly(Database.SqlServer);
 

--- a/StayWize.Domain/Common/ISoftDeletable.cs
+++ b/StayWize.Domain/Common/ISoftDeletable.cs
@@ -1,0 +1,6 @@
+﻿namespace StayWize.Domain.Common;
+
+public interface ISoftDeletable
+{
+    bool IsDeleted { get; }
+}

--- a/StayWize.Infrastructure/Persistence/Context/AppDbContext.cs
+++ b/StayWize.Infrastructure/Persistence/Context/AppDbContext.cs
@@ -18,25 +18,25 @@ public class AppDbContext : DbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
-
-        // Aplica todas las configuraciones del assembly automáticamente
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
 
-        // Filtro global de soft delete para todas las entidades que hereden BaseEntity
         foreach (var entityType in modelBuilder.Model.GetEntityTypes())
         {
-            if (typeof(BaseEntity).IsAssignableFrom(entityType.ClrType))
+            if (typeof(ISoftDeletable).IsAssignableFrom(entityType.ClrType))
             {
                 modelBuilder.Entity(entityType.ClrType)
-                    .HasQueryFilter(
-                        System.Linq.Expressions.Expression.Lambda(
-                            System.Linq.Expressions.Expression.Equal(
-                                System.Linq.Expressions.Expression.Property(
-                                    System.Linq.Expressions.Expression.Parameter(entityType.ClrType, "e"),
-                                    nameof(BaseEntity.IsDeleted)),
-                                System.Linq.Expressions.Expression.Constant(false)),
-                            System.Linq.Expressions.Expression.Parameter(entityType.ClrType, "e")));
+                    .HasQueryFilter(BuildSoftDeleteFilter(entityType.ClrType));
             }
         }
+    }
+
+    private static System.Linq.Expressions.LambdaExpression BuildSoftDeleteFilter(Type type)
+    {
+        var param = System.Linq.Expressions.Expression.Parameter(type, "e");
+        var prop = System.Linq.Expressions.Expression.Property(param, nameof(ISoftDeletable.IsDeleted));
+        var condition = System.Linq.Expressions.Expression.Equal(
+            prop,
+            System.Linq.Expressions.Expression.Constant(false));
+        return System.Linq.Expressions.Expression.Lambda(condition, param);
     }
 }


### PR DESCRIPTION
Se añade PropertiesController con endpoints CRUD usando MediatR. Se crean DTOs y handlers para operaciones de propiedades. Se introduce ISoftDeletable y soft delete en BaseEntity. AppDbContext ahora aplica filtro global de soft delete. Se configura la inyección de dependencias para la capa de aplicación y MediatR.