### PR TITLE
Implementa CRUD de HostLocal con CQRS y MediatR

### DIFF
--- a/StayWize.API/Controllers/HostLocalsController.cs
+++ b/StayWize.API/Controllers/HostLocalsController.cs
@@ -1,0 +1,71 @@
+﻿using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using StayWize.Application.DTOs;
+using StayWize.Application.UseCases.HostLocals;
+
+namespace StayWize.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class HostLocalsController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public HostLocalsController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var result = await _mediator.Send(new GetAllHostLocalsQuery());
+        return Ok(result);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetById(Guid id)
+    {
+        var result = await _mediator.Send(new GetHostLocalByIdQuery(id));
+        if (result is null) return NotFound();
+        return Ok(result);
+    }
+
+    [HttpGet("zone/{zone}")]
+    public async Task<IActionResult> GetAvailableByZone(string zone)
+    {
+        var result = await _mediator.Send(new GetAvailableHostLocalsByZoneQuery(zone));
+        return Ok(result);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateHostLocalDto dto)
+    {
+        var result = await _mediator.Send(new CreateHostLocalCommand(dto));
+        return CreatedAtAction(nameof(GetById), new { id = result.Id }, result);
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> Update(Guid id, [FromBody] UpdateHostLocalDto dto)
+    {
+        var result = await _mediator.Send(new UpdateHostLocalCommand(id, dto));
+        if (!result) return NotFound();
+        return NoContent();
+    }
+
+    [HttpPatch("{id:guid}/availability")]
+    public async Task<IActionResult> SetAvailability(Guid id, [FromBody] bool isAvailable)
+    {
+        var result = await _mediator.Send(new SetHostLocalAvailabilityCommand(id, isAvailable));
+        if (!result) return NotFound();
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        var result = await _mediator.Send(new DeleteHostLocalCommand(id));
+        if (!result) return NotFound();
+        return NoContent();
+    }
+}

--- a/StayWize.Application/DTOs/CreateHostLocalDto.cs
+++ b/StayWize.Application/DTOs/CreateHostLocalDto.cs
@@ -1,0 +1,10 @@
+﻿namespace StayWize.Application.DTOs;
+
+public class CreateHostLocalDto
+{
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string Phone { get; set; } = string.Empty;
+    public string Zone { get; set; } = string.Empty;
+}

--- a/StayWize.Application/DTOs/HostLocalDto.cs
+++ b/StayWize.Application/DTOs/HostLocalDto.cs
@@ -1,0 +1,14 @@
+﻿namespace StayWize.Application.DTOs;
+
+public class HostLocalDto
+{
+    public Guid Id { get; set; }
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string Phone { get; set; } = string.Empty;
+    public string Zone { get; set; } = string.Empty;
+    public bool IsAvailable { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+}

--- a/StayWize.Application/DTOs/UpdateHostLocalDto.cs
+++ b/StayWize.Application/DTOs/UpdateHostLocalDto.cs
@@ -1,0 +1,10 @@
+﻿namespace StayWize.Application.DTOs;
+
+public class UpdateHostLocalDto
+{
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string Phone { get; set; } = string.Empty;
+    public string Zone { get; set; } = string.Empty;
+}

--- a/StayWize.Application/UseCases/HostLocals/CreateHostLocalCommand.cs
+++ b/StayWize.Application/UseCases/HostLocals/CreateHostLocalCommand.cs
@@ -1,0 +1,52 @@
+﻿using MediatR;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Application.DTOs;
+using StayWize.Domain.Entities;
+
+namespace StayWize.Application.UseCases.HostLocals;
+
+public record CreateHostLocalCommand(CreateHostLocalDto Dto) : IRequest<HostLocalDto>;
+
+public class CreateHostLocalCommandHandler
+    : IRequestHandler<CreateHostLocalCommand, HostLocalDto>
+{
+    private readonly IHostLocalRepository _repository;
+
+    public CreateHostLocalCommandHandler(IHostLocalRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<HostLocalDto> Handle(
+        CreateHostLocalCommand request,
+        CancellationToken cancellationToken)
+    {
+        var dto = request.Dto;
+
+        var existing = await _repository.GetAllAsync();
+        if (existing.Any(h => h.Email == dto.Email))
+            throw new InvalidOperationException($"Ya existe un host local con el email {dto.Email}.");
+
+        var hostLocal = HostLocal.Create(
+            dto.FirstName,
+            dto.LastName,
+            dto.Email,
+            dto.Phone,
+            dto.Zone);
+
+        await _repository.AddAsync(hostLocal);
+
+        return new HostLocalDto
+        {
+            Id = hostLocal.Id,
+            FirstName = hostLocal.FirstName,
+            LastName = hostLocal.LastName,
+            Email = hostLocal.Email,
+            Phone = hostLocal.Phone,
+            Zone = hostLocal.Zone,
+            IsAvailable = hostLocal.IsAvailable,
+            CreatedAt = hostLocal.CreatedAt,
+            UpdatedAt = hostLocal.UpdatedAt
+        };
+    }
+}

--- a/StayWize.Application/UseCases/HostLocals/DeleteHostLocalCommand.cs
+++ b/StayWize.Application/UseCases/HostLocals/DeleteHostLocalCommand.cs
@@ -1,0 +1,31 @@
+﻿using MediatR;
+using StayWize.Application.Common.Interfaces;
+
+namespace StayWize.Application.UseCases.HostLocals;
+
+public record DeleteHostLocalCommand(Guid Id) : IRequest<bool>;
+
+public class DeleteHostLocalCommandHandler
+    : IRequestHandler<DeleteHostLocalCommand, bool>
+{
+    private readonly IHostLocalRepository _repository;
+
+    public DeleteHostLocalCommandHandler(IHostLocalRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<bool> Handle(
+        DeleteHostLocalCommand request,
+        CancellationToken cancellationToken)
+    {
+        var hostLocal = await _repository.GetByIdAsync(request.Id);
+
+        if (hostLocal is null) return false;
+
+        hostLocal.SoftDelete("system");
+        await _repository.UpdateAsync(hostLocal);
+
+        return true;
+    }
+}

--- a/StayWize.Application/UseCases/HostLocals/GetAllHostLocalsQuery.cs
+++ b/StayWize.Application/UseCases/HostLocals/GetAllHostLocalsQuery.cs
@@ -1,0 +1,38 @@
+﻿using MediatR;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Application.DTOs;
+
+namespace StayWize.Application.UseCases.HostLocals;
+
+public record GetAllHostLocalsQuery : IRequest<IEnumerable<HostLocalDto>>;
+
+public class GetAllHostLocalsQueryHandler
+    : IRequestHandler<GetAllHostLocalsQuery, IEnumerable<HostLocalDto>>
+{
+    private readonly IHostLocalRepository _repository;
+
+    public GetAllHostLocalsQueryHandler(IHostLocalRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<IEnumerable<HostLocalDto>> Handle(
+        GetAllHostLocalsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var hostLocals = await _repository.GetAllAsync();
+
+        return hostLocals.Select(h => new HostLocalDto
+        {
+            Id = h.Id,
+            FirstName = h.FirstName,
+            LastName = h.LastName,
+            Email = h.Email,
+            Phone = h.Phone,
+            Zone = h.Zone,
+            IsAvailable = h.IsAvailable,
+            CreatedAt = h.CreatedAt,
+            UpdatedAt = h.UpdatedAt
+        });
+    }
+}

--- a/StayWize.Application/UseCases/HostLocals/GetAvailableHostLocalsByZoneQuery.cs
+++ b/StayWize.Application/UseCases/HostLocals/GetAvailableHostLocalsByZoneQuery.cs
@@ -1,0 +1,38 @@
+﻿using MediatR;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Application.DTOs;
+
+namespace StayWize.Application.UseCases.HostLocals;
+
+public record GetAvailableHostLocalsByZoneQuery(string Zone) : IRequest<IEnumerable<HostLocalDto>>;
+
+public class GetAvailableHostLocalsByZoneQueryHandler
+    : IRequestHandler<GetAvailableHostLocalsByZoneQuery, IEnumerable<HostLocalDto>>
+{
+    private readonly IHostLocalRepository _repository;
+
+    public GetAvailableHostLocalsByZoneQueryHandler(IHostLocalRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<IEnumerable<HostLocalDto>> Handle(
+        GetAvailableHostLocalsByZoneQuery request,
+        CancellationToken cancellationToken)
+    {
+        var hostLocals = await _repository.GetAvailableByZoneAsync(request.Zone);
+
+        return hostLocals.Select(h => new HostLocalDto
+        {
+            Id = h.Id,
+            FirstName = h.FirstName,
+            LastName = h.LastName,
+            Email = h.Email,
+            Phone = h.Phone,
+            Zone = h.Zone,
+            IsAvailable = h.IsAvailable,
+            CreatedAt = h.CreatedAt,
+            UpdatedAt = h.UpdatedAt
+        });
+    }
+}

--- a/StayWize.Application/UseCases/HostLocals/GetHostLocalByIdQuery.cs
+++ b/StayWize.Application/UseCases/HostLocals/GetHostLocalByIdQuery.cs
@@ -1,0 +1,40 @@
+﻿using MediatR;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Application.DTOs;
+
+namespace StayWize.Application.UseCases.HostLocals;
+
+public record GetHostLocalByIdQuery(Guid Id) : IRequest<HostLocalDto?>;
+
+public class GetHostLocalByIdQueryHandler
+    : IRequestHandler<GetHostLocalByIdQuery, HostLocalDto?>
+{
+    private readonly IHostLocalRepository _repository;
+
+    public GetHostLocalByIdQueryHandler(IHostLocalRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<HostLocalDto?> Handle(
+        GetHostLocalByIdQuery request,
+        CancellationToken cancellationToken)
+    {
+        var hostLocal = await _repository.GetByIdAsync(request.Id);
+
+        if (hostLocal is null) return null;
+
+        return new HostLocalDto
+        {
+            Id = hostLocal.Id,
+            FirstName = hostLocal.FirstName,
+            LastName = hostLocal.LastName,
+            Email = hostLocal.Email,
+            Phone = hostLocal.Phone,
+            Zone = hostLocal.Zone,
+            IsAvailable = hostLocal.IsAvailable,
+            CreatedAt = hostLocal.CreatedAt,
+            UpdatedAt = hostLocal.UpdatedAt
+        };
+    }
+}

--- a/StayWize.Application/UseCases/HostLocals/SetHostLocalAvailabilityCommand.cs
+++ b/StayWize.Application/UseCases/HostLocals/SetHostLocalAvailabilityCommand.cs
@@ -1,0 +1,32 @@
+﻿using MediatR;
+using StayWize.Application.Common.Interfaces;
+
+namespace StayWize.Application.UseCases.HostLocals;
+
+public record SetHostLocalAvailabilityCommand(Guid Id, bool IsAvailable) : IRequest<bool>;
+
+public class SetHostLocalAvailabilityCommandHandler
+    : IRequestHandler<SetHostLocalAvailabilityCommand, bool>
+{
+    private readonly IHostLocalRepository _repository;
+
+    public SetHostLocalAvailabilityCommandHandler(IHostLocalRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<bool> Handle(
+        SetHostLocalAvailabilityCommand request,
+        CancellationToken cancellationToken)
+    {
+        var hostLocal = await _repository.GetByIdAsync(request.Id);
+
+        if (hostLocal is null) return false;
+
+        hostLocal.SetAvailability(request.IsAvailable);
+        hostLocal.MarkAsUpdated("system");
+        await _repository.UpdateAsync(hostLocal);
+
+        return true;
+    }
+}

--- a/StayWize.Application/UseCases/HostLocals/UpdateHostLocalCommand.cs
+++ b/StayWize.Application/UseCases/HostLocals/UpdateHostLocalCommand.cs
@@ -1,0 +1,39 @@
+﻿using MediatR;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Application.DTOs;
+
+namespace StayWize.Application.UseCases.HostLocals;
+
+public record UpdateHostLocalCommand(Guid Id, UpdateHostLocalDto Dto) : IRequest<bool>;
+
+public class UpdateHostLocalCommandHandler
+    : IRequestHandler<UpdateHostLocalCommand, bool>
+{
+    private readonly IHostLocalRepository _repository;
+
+    public UpdateHostLocalCommandHandler(IHostLocalRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<bool> Handle(
+        UpdateHostLocalCommand request,
+        CancellationToken cancellationToken)
+    {
+        var hostLocal = await _repository.GetByIdAsync(request.Id);
+
+        if (hostLocal is null) return false;
+
+        hostLocal.Update(
+            request.Dto.FirstName,
+            request.Dto.LastName,
+            request.Dto.Email,
+            request.Dto.Phone,
+            request.Dto.Zone);
+
+        hostLocal.MarkAsUpdated("system");
+        await _repository.UpdateAsync(hostLocal);
+
+        return true;
+    }
+}


### PR DESCRIPTION
Se añade el controlador, DTOs y casos de uso para HostLocal. Permite listar, consultar, crear, actualizar, cambiar disponibilidad y eliminar (soft delete) hosts locales. Se utiliza MediatR y patrón CQRS con repositorios.