### PR TITLE
Integrar Serilog y abstracción de logging en StayWize

### DIFF
--- a/StayWize.API/Program.cs
+++ b/StayWize.API/Program.cs
@@ -1,29 +1,56 @@
+using Serilog;
 using StayWize.Application;
 using StayWize.Infrastructure;
+using StayWize.Services;
 using StayWize.Services.ExceptionHandling;
 
-var builder = WebApplication.CreateBuilder(args);
+Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Information()
+    .WriteTo.Console(outputTemplate:
+        "[{Timestamp:yyyy-MM-dd HH:mm:ss}] [{Level:u3}] {Message:lj}{NewLine}{Exception}")
+    .WriteTo.File("logs/staywize-.log",
+        rollingInterval: RollingInterval.Day,
+        outputTemplate:
+        "[{Timestamp:yyyy-MM-dd HH:mm:ss}] [{Level:u3}] {Message:lj}{NewLine}{Exception}")
+    .CreateLogger();
 
-builder.Services.AddControllers();
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
-
-builder.Services.AddApplication();
-builder.Services.AddInfrastructure(builder.Configuration);
-
-var app = builder.Build();
-
-// Debe ser el primer middleware en el pipeline
-app.UseExceptionHandling();
-
-if (app.Environment.IsDevelopment())
+try
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
+    Log.Information("Iniciando StayWize API...");
+
+    var builder = WebApplication.CreateBuilder(args);
+
+    builder.Host.UseSerilog();
+
+    builder.Services.AddControllers();
+    builder.Services.AddEndpointsApiExplorer();
+    builder.Services.AddSwaggerGen();
+
+    builder.Services.AddApplication();
+    builder.Services.AddInfrastructure(builder.Configuration);
+    builder.Services.AddServices();
+
+    var app = builder.Build();
+
+    app.UseExceptionHandling();
+
+    if (app.Environment.IsDevelopment())
+    {
+        app.UseSwagger();
+        app.UseSwaggerUI();
+    }
+
+    app.UseHttpsRedirection();
+    app.UseAuthorization();
+    app.MapControllers();
+
+    app.Run();
 }
-
-app.UseHttpsRedirection();
-app.UseAuthorization();
-app.MapControllers();
-
-app.Run();
+catch (Exception ex)
+{
+    Log.Fatal(ex, "La aplicación terminó inesperadamente.");
+}
+finally
+{
+    Log.CloseAndFlush();
+}

--- a/StayWize.API/StayWize.API.csproj
+++ b/StayWize.API/StayWize.API.csproj
@@ -15,6 +15,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 

--- a/StayWize.Application/UseCases/AccessCodes/ValidateAccessCodeCommand.cs
+++ b/StayWize.Application/UseCases/AccessCodes/ValidateAccessCodeCommand.cs
@@ -2,6 +2,7 @@
 using StayWize.Application.Common.Interfaces;
 using StayWize.Application.DTOs;
 using StayWize.Domain.Entities;
+using StayWize.Services.Logging;
 
 namespace StayWize.Application.UseCases.AccessCodes;
 
@@ -13,13 +14,16 @@ public class ValidateAccessCodeCommandHandler
 {
     private readonly IAccessCodeRepository _accessCodeRepository;
     private readonly IAccessLogRepository _accessLogRepository;
+    private readonly ILogService _logService;
 
     public ValidateAccessCodeCommandHandler(
         IAccessCodeRepository accessCodeRepository,
-        IAccessLogRepository accessLogRepository)
+        IAccessLogRepository accessLogRepository,
+        ILogService logService)
     {
         _accessCodeRepository = accessCodeRepository;
         _accessLogRepository = accessLogRepository;
+        _logService = logService;
     }
 
     public async Task<ValidateAccessCodeResultDto> Handle(
@@ -29,9 +33,9 @@ public class ValidateAccessCodeCommandHandler
         var dto = request.Dto;
         var accessCode = await _accessCodeRepository.GetByCodeAsync(dto.Code);
 
-        // Código no encontrado
         if (accessCode is null)
         {
+            _logService.LogWarning("Intento de validación con código inexistente. Code: {Code}", dto.Code);
             return new ValidateAccessCodeResultDto
             {
                 Success = false,
@@ -39,9 +43,10 @@ public class ValidateAccessCodeCommandHandler
             };
         }
 
-        // Código inválido (vencido, revocado, fuera de rango)
         if (!accessCode.IsValid())
         {
+            _logService.LogWarning("Código de acceso inválido. Code: {Code} Estado: {Status}", dto.Code, accessCode.Status);
+
             var log = AccessLog.CreateFailure(
                 accessCode.Id,
                 accessCode.ReservationId,
@@ -59,13 +64,15 @@ public class ValidateAccessCodeCommandHandler
             };
         }
 
-        // Código válido — registrar evento exitoso
         var successLog = AccessLog.CreateSuccess(
             accessCode.Id,
             accessCode.ReservationId,
             dto.EventType);
 
         await _accessLogRepository.AddAsync(successLog);
+
+        _logService.LogInformation("Acceso validado exitosamente. Code: {Code} ReservationId: {ReservationId} EventType: {EventType}",
+            dto.Code, accessCode.ReservationId, dto.EventType);
 
         return new ValidateAccessCodeResultDto
         {

--- a/StayWize.Application/UseCases/Reservations/CreateReservationCommand.cs
+++ b/StayWize.Application/UseCases/Reservations/CreateReservationCommand.cs
@@ -5,6 +5,7 @@ using StayWize.Application.DTOs;
 using StayWize.Domain.Entities;
 using StayWize.Domain.Exceptions;
 using StayWize.Services.ExceptionHandling;
+using StayWize.Services.Logging;
 
 namespace StayWize.Application.UseCases.Reservations;
 
@@ -17,17 +18,20 @@ public class CreateReservationCommandHandler
     private readonly IPropertyRepository _propertyRepository;
     private readonly IClientRepository _clientRepository;
     private readonly ReservationConcurrencyService _concurrencyService;
+    private readonly ILogService _logService;
 
     public CreateReservationCommandHandler(
         IReservationRepository reservationRepository,
         IPropertyRepository propertyRepository,
         IClientRepository clientRepository,
-        ReservationConcurrencyService concurrencyService)
+        ReservationConcurrencyService concurrencyService,
+        ILogService logService)
     {
         _reservationRepository = reservationRepository;
         _propertyRepository = propertyRepository;
         _clientRepository = clientRepository;
         _concurrencyService = concurrencyService;
+        _logService = logService;
     }
 
     public async Task<ReservationDto> Handle(
@@ -36,24 +40,31 @@ public class CreateReservationCommandHandler
     {
         var dto = request.Dto;
 
-        // Validar existencia de propiedad y cliente
         var propertyExists = await _propertyRepository.ExistsAsync(dto.PropertyId);
         if (!propertyExists)
+        {
+            _logService.LogWarning("Intento de reserva con propiedad inexistente. PropertyId: {PropertyId}", dto.PropertyId);
             throw new NotFoundException("Propiedad", dto.PropertyId);
+        }
 
         var clientExists = await _clientRepository.ExistsAsync(dto.ClientId);
         if (!clientExists)
+        {
+            _logService.LogWarning("Intento de reserva con cliente inexistente. ClientId: {ClientId}", dto.ClientId);
             throw new NotFoundException("Cliente", dto.ClientId);
+        }
 
-        // Adquirir lock sobre la propiedad (Opción C)
         using var propertyLock = await _concurrencyService.AcquirePropertyLockAsync(dto.PropertyId);
 
-        // Validar solapamiento de fechas (dentro del lock)
         var hasOverlap = await _reservationRepository.HasOverlapAsync(
             dto.PropertyId, dto.CheckIn, dto.CheckOut);
 
         if (hasOverlap)
+        {
+            _logService.LogWarning("Conflicto de fechas. PropertyId: {PropertyId} CheckIn: {CheckIn} CheckOut: {CheckOut}",
+                dto.PropertyId, dto.CheckIn, dto.CheckOut);
             throw new ConflictException("La propiedad ya tiene una reserva activa en el rango de fechas indicado.");
+        }
 
         var reservation = Reservation.Create(
             dto.PropertyId,
@@ -63,10 +74,11 @@ public class CreateReservationCommandHandler
             dto.GuestCount,
             dto.Notes);
 
-        // Opción A: EF Core detectará conflictos de RowVersion al guardar
         try
         {
             await _reservationRepository.AddAsync(reservation);
+            _logService.LogInformation("Reserva creada. ReservationId: {ReservationId} PropertyId: {PropertyId} ClientId: {ClientId}",
+                reservation.Id, reservation.PropertyId, reservation.ClientId);
         }
         catch (Exception ex) when (ex.GetType().Name == "DbUpdateConcurrencyException")
         {

--- a/StayWize.Services/DependencyInjection.cs
+++ b/StayWize.Services/DependencyInjection.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using StayWize.Services.Logging;
+
+namespace StayWize.Services;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddServices(this IServiceCollection services)
+    {
+        services.AddSingleton<ILogService, LogService>();
+        return services;
+    }
+}

--- a/StayWize.Services/ExceptionHandling/ExceptionHandlingMiddleware.cs
+++ b/StayWize.Services/ExceptionHandling/ExceptionHandlingMiddleware.cs
@@ -1,23 +1,22 @@
-﻿using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
-using StayWize.Domain.Exceptions;
-using System.Data;
-using System.Net;
+﻿using System.Net;
 using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using StayWize.Domain.Exceptions;
+using StayWize.Services.Logging;
 
 namespace StayWize.Services.ExceptionHandling;
 
 public class ExceptionHandlingMiddleware
 {
     private readonly RequestDelegate _next;
-    private readonly ILogger<ExceptionHandlingMiddleware> _logger;
+    private readonly ILogService _logService;
 
     public ExceptionHandlingMiddleware(
         RequestDelegate next,
-        ILogger<ExceptionHandlingMiddleware> logger)
+        ILogService logService)
     {
         _next = next;
-        _logger = logger;
+        _logService = logService;
     }
 
     public async Task InvokeAsync(HttpContext context)
@@ -28,7 +27,7 @@ public class ExceptionHandlingMiddleware
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Excepción no controlada: {Message}", ex.Message);
+            _logService.LogError("Excepción no controlada: {Message}", ex, ex.Message);
             await HandleExceptionAsync(context, ex);
         }
     }

--- a/StayWize.Services/Logging/ILogService.cs
+++ b/StayWize.Services/Logging/ILogService.cs
@@ -1,0 +1,8 @@
+﻿namespace StayWize.Services.Logging;
+
+public interface ILogService
+{
+    void LogInformation(string message, params object[] args);
+    void LogWarning(string message, params object[] args);
+    void LogError(string message, Exception? exception = null, params object[] args);
+}

--- a/StayWize.Services/Logging/LogService.cs
+++ b/StayWize.Services/Logging/LogService.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace StayWize.Services.Logging;
+
+public class LogService : ILogService
+{
+    private readonly ILogger<LogService> _logger;
+
+    public LogService(ILogger<LogService> logger)
+    {
+        _logger = logger;
+    }
+
+    public void LogInformation(string message, params object[] args)
+    {
+        _logger.LogInformation(message, args);
+    }
+
+    public void LogWarning(string message, params object[] args)
+    {
+        _logger.LogWarning(message, args);
+    }
+
+    public void LogError(string message, Exception? exception = null, params object[] args)
+    {
+        if (exception is not null)
+            _logger.LogError(exception, message, args);
+        else
+            _logger.LogError(message, args);
+    }
+}

--- a/StayWize.Services/StayWize.Services.csproj
+++ b/StayWize.Services/StayWize.Services.csproj
@@ -7,6 +7,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Serilog" Version="4.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Se ha integrado Serilog como sistema de logging estructurado, configurando salida a consola y archivos. Se crea la abstracción ILogService y su implementación, registrando eventos relevantes en los handlers y middleware. Se actualiza la inicialización para usar Serilog como logger principal.