### PR TITLE
Expira códigos de acceso con job en segundo plano

### DIFF
--- a/StayWize.API/appsettings.json
+++ b/StayWize.API/appsettings.json
@@ -25,5 +25,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "JobSettings": {
+    "AccessCodeExpirationIntervalMinutes": "PLACEHOLDER"
+  },
   "AllowedHosts": "*"
 }

--- a/StayWize.Application/Common/Interfaces/IAccessCodeRepository.cs
+++ b/StayWize.Application/Common/Interfaces/IAccessCodeRepository.cs
@@ -6,4 +6,5 @@ public interface IAccessCodeRepository : IRepository<AccessCode>
 {
     Task<AccessCode?> GetByCodeAsync(string code);
     Task<IEnumerable<AccessCode>> GetByReservationIdAsync(Guid reservationId);
+    Task<IEnumerable<AccessCode>> GetExpiredActiveCodesAsync();
 }

--- a/StayWize.Infrastructure/DependencyInjection.cs
+++ b/StayWize.Infrastructure/DependencyInjection.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using StayWize.Application.Common.Interfaces;
+using StayWize.Infrastructure.Jobs;
 using StayWize.Infrastructure.Persistence.Context;
 using StayWize.Infrastructure.Persistence.Repositories;
 using StayWize.Services.Authentication;
@@ -36,6 +37,9 @@ public static class DependencyInjection
         services.AddScoped<IReservationRepository, ReservationRepository>();
         services.AddScoped<IAccessCodeRepository, AccessCodeRepository>();
         services.AddScoped<IAccessLogRepository, AccessLogRepository>();
+
+        // Background job
+        services.AddHostedService<AccessCodeExpirationJob>();
 
         return services;
     }

--- a/StayWize.Infrastructure/Jobs/AccessCodeExpirationJob.cs
+++ b/StayWize.Infrastructure/Jobs/AccessCodeExpirationJob.cs
@@ -1,0 +1,101 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Services.Notifications;
+
+namespace StayWize.Infrastructure.Jobs;
+
+public class AccessCodeExpirationJob : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<AccessCodeExpirationJob> _logger;
+    private readonly TimeSpan _interval;
+
+    public AccessCodeExpirationJob(
+        IServiceScopeFactory scopeFactory,
+        ILogger<AccessCodeExpirationJob> logger,
+        IConfiguration configuration)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+
+        var minutes = int.Parse(
+            configuration["JobSettings:AccessCodeExpirationIntervalMinutes"] ?? "15");
+        _interval = TimeSpan.FromMinutes(minutes);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("AccessCodeExpirationJob iniciado. Intervalo: {Interval} minutos.", _interval.TotalMinutes);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await ProcessExpiredCodesAsync();
+            await Task.Delay(_interval, stoppingToken);
+        }
+    }
+
+    private async Task ProcessExpiredCodesAsync()
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+
+            var accessCodeRepository = scope.ServiceProvider.GetRequiredService<IAccessCodeRepository>();
+            var clientRepository = scope.ServiceProvider.GetRequiredService<IClientRepository>();
+            var propertyRepository = scope.ServiceProvider.GetRequiredService<IPropertyRepository>();
+            var reservationRepository = scope.ServiceProvider.GetRequiredService<IReservationRepository>();
+            var emailService = scope.ServiceProvider.GetRequiredService<IEmailService>();
+
+            var expiredCodes = await accessCodeRepository.GetExpiredActiveCodesAsync();
+            var codesList = expiredCodes.ToList();
+
+            if (!codesList.Any())
+            {
+                _logger.LogInformation("AccessCodeExpirationJob: no hay códigos para expirar.");
+                return;
+            }
+
+            int processed = 0;
+
+            foreach (var code in codesList)
+            {
+                try
+                {
+                    code.MarkAsExpired();
+                    code.MarkAsUpdated("system");
+                    await accessCodeRepository.UpdateAsync(code);
+
+                    // Notificación al cliente
+                    if (code.Reservation is not null)
+                    {
+                        var client = await clientRepository.GetByIdAsync(code.Reservation.ClientId);
+                        var property = await propertyRepository.GetByIdAsync(code.Reservation.PropertyId);
+
+                        if (client is not null && property is not null)
+                        {
+                            _ = emailService.SendAccessCodeExpiredAsync(
+                                client.Email,
+                                $"{client.FirstName} {client.LastName}",
+                                property.Name);
+                        }
+                    }
+
+                    processed++;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error al expirar código {CodeId}", code.Id);
+                }
+            }
+
+            _logger.LogInformation("AccessCodeExpirationJob: {Count} códigos expirados.", processed);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error general en AccessCodeExpirationJob.");
+        }
+    }
+}

--- a/StayWize.Infrastructure/Persistence/Repositories/AccessCodeRepository.cs
+++ b/StayWize.Infrastructure/Persistence/Repositories/AccessCodeRepository.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using StayWize.Application.Common.Interfaces;
 using StayWize.Domain.Entities;
+using StayWize.Domain.Enums;
 using StayWize.Infrastructure.Persistence.Context;
 
 namespace StayWize.Infrastructure.Persistence.Repositories;
@@ -20,6 +21,15 @@ public class AccessCodeRepository : BaseRepository<AccessCode>, IAccessCodeRepos
     {
         return await _dbSet
             .Where(a => a.ReservationId == reservationId)
+            .ToListAsync();
+    }
+
+    public async Task<IEnumerable<AccessCode>> GetExpiredActiveCodesAsync()
+    {
+        var now = DateTime.UtcNow;
+        return await _dbSet
+            .Where(a => a.Status == AccessCodeStatus.Active && a.ValidTo < now)
+            .Include(a => a.Reservation)
             .ToListAsync();
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - SmtpSettings__Password=${SMTP_PASSWORD}
       - SmtpSettings__FromName=${SMTP_FROM_NAME}
       - SmtpSettings__FromEmail=${SMTP_FROM_EMAIL}
+      - JobSettings__AccessCodeExpirationIntervalMinutes=${JOB_EXPIRATION_INTERVAL_MINUTES}
+
     depends_on:
       staywize-db:
         condition: service_healthy


### PR DESCRIPTION
Se implementa AccessCodeExpirationJob como servicio en segundo plano para expirar automáticamente códigos de acceso activos vencidos. Se configura el intervalo por parámetro en la configuración. Se amplía IAccessCodeRepository y su repositorio, y se añade notificación por email al cliente. Se registra el job en la inyección de dependencias.