### PR TITLE
Añade dashboards global y por propiedad a la API

### DIFF
--- a/StayWize.API/Controllers/DashboardController.cs
+++ b/StayWize.API/Controllers/DashboardController.cs
@@ -1,0 +1,42 @@
+﻿using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using StayWize.Application.UseCases.Dashboard;
+
+namespace StayWize.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class DashboardController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public DashboardController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet("property/{propertyId:guid}")]
+    [Authorize(Roles = "Admin,Owner")]
+    public async Task<IActionResult> GetPropertyDashboard(
+        Guid propertyId,
+        [FromQuery] DateTime? dateFrom,
+        [FromQuery] DateTime? dateTo)
+    {
+        var result = await _mediator.Send(
+            new GetPropertyDashboardQuery(propertyId, dateFrom, dateTo));
+        return Ok(result);
+    }
+
+    [HttpGet("global")]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> GetGlobalDashboard(
+        [FromQuery] DateTime? dateFrom,
+        [FromQuery] DateTime? dateTo)
+    {
+        var result = await _mediator.Send(
+            new GetGlobalDashboardQuery(dateFrom, dateTo));
+        return Ok(result);
+    }
+}

--- a/StayWize.Application/Common/Interfaces/IAccessCodeRepository.cs
+++ b/StayWize.Application/Common/Interfaces/IAccessCodeRepository.cs
@@ -7,4 +7,5 @@ public interface IAccessCodeRepository : IRepository<AccessCode>
     Task<AccessCode?> GetByCodeAsync(string code);
     Task<IEnumerable<AccessCode>> GetByReservationIdAsync(Guid reservationId);
     Task<IEnumerable<AccessCode>> GetExpiredActiveCodesAsync();
+    Task<IEnumerable<AccessCode>> GetByReservationIdsAsync(IEnumerable<Guid> reservationIds);
 }

--- a/StayWize.Application/Common/Interfaces/IAccessLogRepository.cs
+++ b/StayWize.Application/Common/Interfaces/IAccessLogRepository.cs
@@ -6,4 +6,5 @@ public interface IAccessLogRepository : IRepository<AccessLog>
 {
     Task<IEnumerable<AccessLog>> GetByReservationIdAsync(Guid reservationId);
     Task<IEnumerable<AccessLog>> GetByAccessCodeIdAsync(Guid accessCodeId);
+    Task<IEnumerable<AccessLog>> GetByReservationIdsAndDateRangeAsync(IEnumerable<Guid> reservationIds, DateTime dateFrom, DateTime dateTo);
 }

--- a/StayWize.Application/Common/Interfaces/IReservationRepository.cs
+++ b/StayWize.Application/Common/Interfaces/IReservationRepository.cs
@@ -7,4 +7,6 @@ public interface IReservationRepository : IRepository<Reservation>
     Task<IEnumerable<Reservation>> GetByPropertyIdAsync(Guid propertyId);
     Task<IEnumerable<Reservation>> GetByClientIdAsync(Guid clientId);
     Task<bool> HasOverlapAsync(Guid propertyId, DateTime checkIn, DateTime checkOut);
+    Task<IEnumerable<Reservation>> GetByPropertyIdAndDateRangeAsync(Guid propertyId, DateTime dateFrom, DateTime dateTo);
+    Task<IEnumerable<Reservation>> GetByDateRangeAsync(DateTime dateFrom, DateTime dateTo);
 }

--- a/StayWize.Application/DTOs/Dashboard/GlobalDashboardDto.cs
+++ b/StayWize.Application/DTOs/Dashboard/GlobalDashboardDto.cs
@@ -1,0 +1,14 @@
+﻿namespace StayWize.Application.DTOs.Dashboard;
+
+public class GlobalDashboardDto
+{
+    public DateTime DateFrom { get; set; }
+    public DateTime DateTo { get; set; }
+    public int TotalProperties { get; set; }
+    public int TotalClients { get; set; }
+    public int TotalReservations { get; set; }
+    public int TotalEntries { get; set; }
+    public int TotalExits { get; set; }
+    public int SuccessfulAccesses { get; set; }
+    public int FailedAccesses { get; set; }
+}

--- a/StayWize.Application/DTOs/Dashboard/PropertyDashboardDto.cs
+++ b/StayWize.Application/DTOs/Dashboard/PropertyDashboardDto.cs
@@ -1,0 +1,18 @@
+﻿namespace StayWize.Application.DTOs.Dashboard;
+
+public class PropertyDashboardDto
+{
+    public Guid PropertyId { get; set; }
+    public string PropertyName { get; set; } = string.Empty;
+    public DateTime DateFrom { get; set; }
+    public DateTime DateTo { get; set; }
+    public int TotalReservations { get; set; }
+    public int ActiveReservations { get; set; }
+    public int TotalEntries { get; set; }
+    public int TotalExits { get; set; }
+    public int SuccessfulAccesses { get; set; }
+    public int FailedAccesses { get; set; }
+    public int ActiveAccessCodes { get; set; }
+    public int ExpiredAccessCodes { get; set; }
+    public int RevokedAccessCodes { get; set; }
+}

--- a/StayWize.Application/UseCases/Dashboard/GetGlobalDashboardQuery.cs
+++ b/StayWize.Application/UseCases/Dashboard/GetGlobalDashboardQuery.cs
@@ -1,0 +1,64 @@
+﻿using MediatR;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Application.DTOs.Dashboard;
+using StayWize.Domain.Enums;
+
+namespace StayWize.Application.UseCases.Dashboard;
+
+public record GetGlobalDashboardQuery(
+    DateTime? DateFrom,
+    DateTime? DateTo) : IRequest<GlobalDashboardDto>;
+
+public class GetGlobalDashboardQueryHandler
+    : IRequestHandler<GetGlobalDashboardQuery, GlobalDashboardDto>
+{
+    private readonly IPropertyRepository _propertyRepository;
+    private readonly IClientRepository _clientRepository;
+    private readonly IReservationRepository _reservationRepository;
+    private readonly IAccessLogRepository _accessLogRepository;
+
+    public GetGlobalDashboardQueryHandler(
+        IPropertyRepository propertyRepository,
+        IClientRepository clientRepository,
+        IReservationRepository reservationRepository,
+        IAccessLogRepository accessLogRepository)
+    {
+        _propertyRepository = propertyRepository;
+        _clientRepository = clientRepository;
+        _reservationRepository = reservationRepository;
+        _accessLogRepository = accessLogRepository;
+    }
+
+    public async Task<GlobalDashboardDto> Handle(
+        GetGlobalDashboardQuery request,
+        CancellationToken cancellationToken)
+    {
+        var dateFrom = request.DateFrom ?? DateTime.UtcNow.AddMonths(-1);
+        var dateTo = request.DateTo ?? DateTime.UtcNow;
+
+        var properties = await _propertyRepository.GetAllAsync();
+        var clients = await _clientRepository.GetAllAsync();
+        var reservations = (await _reservationRepository
+            .GetByDateRangeAsync(dateFrom, dateTo)).ToList();
+
+        var reservationIds = reservations.Select(r => r.Id).ToList();
+
+        var accessLogs = reservationIds.Any()
+            ? (await _accessLogRepository.GetByReservationIdsAndDateRangeAsync(
+                reservationIds, dateFrom, dateTo)).ToList()
+            : new List<Domain.Entities.AccessLog>();
+
+        return new GlobalDashboardDto
+        {
+            DateFrom = dateFrom,
+            DateTo = dateTo,
+            TotalProperties = properties.Count(),
+            TotalClients = clients.Count(),
+            TotalReservations = reservations.Count,
+            TotalEntries = accessLogs.Count(l => l.EventType == AccessEventType.Entry),
+            TotalExits = accessLogs.Count(l => l.EventType == AccessEventType.Exit),
+            SuccessfulAccesses = accessLogs.Count(l => l.Success),
+            FailedAccesses = accessLogs.Count(l => !l.Success)
+        };
+    }
+}

--- a/StayWize.Application/UseCases/Dashboard/GetPropertyDashboardQuery.cs
+++ b/StayWize.Application/UseCases/Dashboard/GetPropertyDashboardQuery.cs
@@ -1,0 +1,79 @@
+﻿using MediatR;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Application.DTOs.Dashboard;
+using StayWize.Domain.Enums;
+using StayWize.Services.ExceptionHandling;
+
+namespace StayWize.Application.UseCases.Dashboard;
+
+public record GetPropertyDashboardQuery(
+    Guid PropertyId,
+    DateTime? DateFrom,
+    DateTime? DateTo) : IRequest<PropertyDashboardDto>;
+
+public class GetPropertyDashboardQueryHandler
+    : IRequestHandler<GetPropertyDashboardQuery, PropertyDashboardDto>
+{
+    private readonly IPropertyRepository _propertyRepository;
+    private readonly IReservationRepository _reservationRepository;
+    private readonly IAccessCodeRepository _accessCodeRepository;
+    private readonly IAccessLogRepository _accessLogRepository;
+
+    public GetPropertyDashboardQueryHandler(
+        IPropertyRepository propertyRepository,
+        IReservationRepository reservationRepository,
+        IAccessCodeRepository accessCodeRepository,
+        IAccessLogRepository accessLogRepository)
+    {
+        _propertyRepository = propertyRepository;
+        _reservationRepository = reservationRepository;
+        _accessCodeRepository = accessCodeRepository;
+        _accessLogRepository = accessLogRepository;
+    }
+
+    public async Task<PropertyDashboardDto> Handle(
+        GetPropertyDashboardQuery request,
+        CancellationToken cancellationToken)
+    {
+        var property = await _propertyRepository.GetByIdAsync(request.PropertyId);
+        if (property is null)
+            throw new NotFoundException("Propiedad", request.PropertyId);
+
+        var dateFrom = request.DateFrom ?? DateTime.UtcNow.AddMonths(-1);
+        var dateTo = request.DateTo ?? DateTime.UtcNow;
+
+        var reservations = (await _reservationRepository
+            .GetByPropertyIdAndDateRangeAsync(request.PropertyId, dateFrom, dateTo))
+            .ToList();
+
+        var reservationIds = reservations.Select(r => r.Id).ToList();
+
+        var accessCodes = reservationIds.Any()
+            ? (await _accessCodeRepository.GetByReservationIdsAsync(reservationIds)).ToList()
+            : new List<Domain.Entities.AccessCode>();
+
+        var accessLogs = reservationIds.Any()
+            ? (await _accessLogRepository.GetByReservationIdsAndDateRangeAsync(
+                reservationIds, dateFrom, dateTo)).ToList()
+            : new List<Domain.Entities.AccessLog>();
+
+        return new PropertyDashboardDto
+        {
+            PropertyId = property.Id,
+            PropertyName = property.Name,
+            DateFrom = dateFrom,
+            DateTo = dateTo,
+            TotalReservations = reservations.Count,
+            ActiveReservations = reservations.Count(r =>
+                r.Status == ReservationStatus.Confirmed ||
+                r.Status == ReservationStatus.Pending),
+            TotalEntries = accessLogs.Count(l => l.EventType == AccessEventType.Entry),
+            TotalExits = accessLogs.Count(l => l.EventType == AccessEventType.Exit),
+            SuccessfulAccesses = accessLogs.Count(l => l.Success),
+            FailedAccesses = accessLogs.Count(l => !l.Success),
+            ActiveAccessCodes = accessCodes.Count(c => c.Status == AccessCodeStatus.Active),
+            ExpiredAccessCodes = accessCodes.Count(c => c.Status == AccessCodeStatus.Expired),
+            RevokedAccessCodes = accessCodes.Count(c => c.Status == AccessCodeStatus.Revoked)
+        };
+    }
+}

--- a/StayWize.Infrastructure/Persistence/Repositories/AccessCodeRepository.cs
+++ b/StayWize.Infrastructure/Persistence/Repositories/AccessCodeRepository.cs
@@ -32,4 +32,12 @@ public class AccessCodeRepository : BaseRepository<AccessCode>, IAccessCodeRepos
             .Include(a => a.Reservation)
             .ToListAsync();
     }
+
+    public async Task<IEnumerable<AccessCode>> GetByReservationIdsAsync(
+    IEnumerable<Guid> reservationIds)
+    {
+        return await _dbSet
+            .Where(a => reservationIds.Contains(a.ReservationId))
+            .ToListAsync();
+    }
 }

--- a/StayWize.Infrastructure/Persistence/Repositories/AccessLogRepository.cs
+++ b/StayWize.Infrastructure/Persistence/Repositories/AccessLogRepository.cs
@@ -24,4 +24,15 @@ public class AccessLogRepository : BaseRepository<AccessLog>, IAccessLogReposito
             .OrderByDescending(l => l.EventTime)
             .ToListAsync();
     }
+
+    public async Task<IEnumerable<AccessLog>> GetByReservationIdsAndDateRangeAsync(
+    IEnumerable<Guid> reservationIds, DateTime dateFrom, DateTime dateTo)
+    {
+        return await _dbSet
+            .Where(l => reservationIds.Contains(l.ReservationId) &&
+                        l.EventTime >= dateFrom &&
+                        l.EventTime <= dateTo)
+            .OrderByDescending(l => l.EventTime)
+            .ToListAsync();
+    }
 }

--- a/StayWize.Infrastructure/Persistence/Repositories/ReservationRepository.cs
+++ b/StayWize.Infrastructure/Persistence/Repositories/ReservationRepository.cs
@@ -19,6 +19,24 @@ public class ReservationRepository : BaseRepository<Reservation>, IReservationRe
             .ToListAsync();
     }
 
+    public async Task<IEnumerable<Reservation>> GetByPropertyIdAndDateRangeAsync(
+    Guid propertyId, DateTime dateFrom, DateTime dateTo)
+    {
+        return await _dbSet
+            .Where(r => r.PropertyId == propertyId &&
+                        r.CheckIn >= dateFrom &&
+                        r.CheckOut <= dateTo)
+            .ToListAsync();
+    }
+
+    public async Task<IEnumerable<Reservation>> GetByDateRangeAsync(
+        DateTime dateFrom, DateTime dateTo)
+    {
+        return await _dbSet
+            .Where(r => r.CheckIn >= dateFrom && r.CheckOut <= dateTo)
+            .ToListAsync();
+    }
+
     public async Task<IEnumerable<Reservation>> GetByClientIdAsync(Guid clientId)
     {
         return await _dbSet


### PR DESCRIPTION
Se agregan endpoints protegidos para dashboards global y de propiedad. Se crean DTOs y casos de uso para obtener métricas agregadas. Se amplían los repositorios con métodos para consultas por rango de fechas y múltiples IDs.