### PR TITLE
Añadir proyecto y pruebas unitarias para StayWize

### DIFF
--- a/StayWize.UnitTests/Application/AccessCodes/GenerateAccessCodeCommandHandlerTests.cs
+++ b/StayWize.UnitTests/Application/AccessCodes/GenerateAccessCodeCommandHandlerTests.cs
@@ -1,0 +1,109 @@
+﻿using FluentAssertions;
+using Moq;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Application.DTOs;
+using StayWize.Application.UseCases.AccessCodes;
+using StayWize.Domain.Entities;
+using StayWize.Domain.Enums;
+using StayWize.Services.Encryption;
+using StayWize.Services.ExceptionHandling;
+using StayWize.Services.Notifications;
+
+namespace StayWize.UnitTests.Application.AccessCodes;
+
+public class GenerateAccessCodeCommandHandlerTests
+{
+    private readonly Mock<IAccessCodeRepository> _accessCodeRepoMock = new();
+    private readonly Mock<IReservationRepository> _reservationRepoMock = new();
+    private readonly Mock<IClientRepository> _clientRepoMock = new();
+    private readonly Mock<IEncryptionService> _encryptionServiceMock = new();
+    private readonly Mock<IEmailService> _emailServiceMock = new();
+
+    private GenerateAccessCodeCommandHandler CreateHandler() => new(
+        _accessCodeRepoMock.Object,
+        _reservationRepoMock.Object,
+        _clientRepoMock.Object,
+        _encryptionServiceMock.Object,
+        _emailServiceMock.Object);
+
+    [Fact]
+    public async Task Handle_ConfirmedReservation_ShouldGenerateCode()
+    {
+        var reservation = Reservation.Create(
+            Guid.NewGuid(), Guid.NewGuid(),
+            DateTime.UtcNow.AddDays(1),
+            DateTime.UtcNow.AddDays(5), 2);
+        reservation.Confirm();
+
+        var client = Client.Create("Juan", "Pérez", "juan@test.com", "123", "12345");
+
+        _reservationRepoMock.Setup(r => r.GetByIdAsync(reservation.Id))
+            .ReturnsAsync(reservation);
+        _clientRepoMock.Setup(r => r.GetByIdAsync(reservation.ClientId))
+            .ReturnsAsync(client);
+        _encryptionServiceMock.Setup(e => e.Encrypt(It.IsAny<string>()))
+            .Returns("encrypted-code");
+        _encryptionServiceMock.Setup(e => e.Decrypt(It.IsAny<string>()))
+            .Returns("123456");
+
+        var dto = new GenerateAccessCodeDto
+        {
+            ReservationId = reservation.Id,
+            ValidFrom = DateTime.UtcNow.AddDays(1),
+            ValidTo = DateTime.UtcNow.AddDays(5),
+            Type = AccessCodeType.CheckIn
+        };
+
+        var result = await CreateHandler().Handle(
+            new GenerateAccessCodeCommand(dto), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.ReservationId.Should().Be(reservation.Id);
+    }
+
+    [Fact]
+    public async Task Handle_ReservationNotFound_ShouldThrowNotFoundException()
+    {
+        _reservationRepoMock.Setup(r => r.GetByIdAsync(It.IsAny<Guid>()))
+            .ReturnsAsync((Reservation?)null);
+
+        var dto = new GenerateAccessCodeDto
+        {
+            ReservationId = Guid.NewGuid(),
+            ValidFrom = DateTime.UtcNow.AddDays(1),
+            ValidTo = DateTime.UtcNow.AddDays(5),
+            Type = AccessCodeType.CheckIn
+        };
+
+        var action = async () => await CreateHandler().Handle(
+            new GenerateAccessCodeCommand(dto), CancellationToken.None);
+
+        await action.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_ReservationNotConfirmed_ShouldThrowConflictException()
+    {
+        var reservation = Reservation.Create(
+            Guid.NewGuid(), Guid.NewGuid(),
+            DateTime.UtcNow.AddDays(1),
+            DateTime.UtcNow.AddDays(5), 2);
+        // Status es Pending, no Confirmed
+
+        _reservationRepoMock.Setup(r => r.GetByIdAsync(reservation.Id))
+            .ReturnsAsync(reservation);
+
+        var dto = new GenerateAccessCodeDto
+        {
+            ReservationId = reservation.Id,
+            ValidFrom = DateTime.UtcNow.AddDays(1),
+            ValidTo = DateTime.UtcNow.AddDays(5),
+            Type = AccessCodeType.CheckIn
+        };
+
+        var action = async () => await CreateHandler().Handle(
+            new GenerateAccessCodeCommand(dto), CancellationToken.None);
+
+        await action.Should().ThrowAsync<ConflictException>();
+    }
+}

--- a/StayWize.UnitTests/Application/AccessCodes/ValidateAccessCodeCommandHandlerTests.cs
+++ b/StayWize.UnitTests/Application/AccessCodes/ValidateAccessCodeCommandHandlerTests.cs
@@ -1,0 +1,100 @@
+﻿using FluentAssertions;
+using Moq;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Application.DTOs;
+using StayWize.Application.UseCases.AccessCodes;
+using StayWize.Domain.Entities;
+using StayWize.Domain.Enums;
+using StayWize.Services.Encryption;
+using StayWize.Services.Logging;
+
+namespace StayWize.UnitTests.Application.AccessCodes;
+
+public class ValidateAccessCodeCommandHandlerTests
+{
+    private readonly Mock<IAccessCodeRepository> _accessCodeRepoMock = new();
+    private readonly Mock<IAccessLogRepository> _accessLogRepoMock = new();
+    private readonly Mock<ILogService> _logServiceMock = new();
+    private readonly Mock<IEncryptionService> _encryptionServiceMock = new();
+
+    private ValidateAccessCodeCommandHandler CreateHandler() => new(
+        _accessCodeRepoMock.Object,
+        _accessLogRepoMock.Object,
+        _logServiceMock.Object,
+        _encryptionServiceMock.Object);
+
+    [Fact]
+    public async Task Handle_ValidCode_ShouldReturnSuccess()
+    {
+        var accessCode = AccessCode.Create(
+            Guid.NewGuid(),
+            DateTime.UtcNow.AddHours(-1),
+            DateTime.UtcNow.AddHours(1),
+            AccessCodeType.CheckIn);
+
+        _encryptionServiceMock.Setup(e => e.Encrypt(It.IsAny<string>()))
+            .Returns("encrypted-code");
+        _accessCodeRepoMock.Setup(r => r.GetByCodeAsync("encrypted-code"))
+            .ReturnsAsync(accessCode);
+
+        var dto = new ValidateAccessCodeDto
+        {
+            Code = accessCode.Code,
+            EventType = AccessEventType.Entry
+        };
+
+        var result = await CreateHandler().Handle(
+            new ValidateAccessCodeCommand(dto), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ReservationId.Should().Be(accessCode.ReservationId);
+    }
+
+    [Fact]
+    public async Task Handle_CodeNotFound_ShouldReturnFailure()
+    {
+        _encryptionServiceMock.Setup(e => e.Encrypt(It.IsAny<string>()))
+            .Returns("encrypted-code");
+        _accessCodeRepoMock.Setup(r => r.GetByCodeAsync(It.IsAny<string>()))
+            .ReturnsAsync((AccessCode?)null);
+
+        var dto = new ValidateAccessCodeDto
+        {
+            Code = "999999",
+            EventType = AccessEventType.Entry
+        };
+
+        var result = await CreateHandler().Handle(
+            new ValidateAccessCodeCommand(dto), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.FailureReason.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_RevokedCode_ShouldReturnFailure()
+    {
+        var accessCode = AccessCode.Create(
+            Guid.NewGuid(),
+            DateTime.UtcNow.AddHours(-1),
+            DateTime.UtcNow.AddHours(1),
+            AccessCodeType.CheckIn);
+        accessCode.Revoke();
+
+        _encryptionServiceMock.Setup(e => e.Encrypt(It.IsAny<string>()))
+            .Returns("encrypted-code");
+        _accessCodeRepoMock.Setup(r => r.GetByCodeAsync("encrypted-code"))
+            .ReturnsAsync(accessCode);
+
+        var dto = new ValidateAccessCodeDto
+        {
+            Code = accessCode.Code,
+            EventType = AccessEventType.Entry
+        };
+
+        var result = await CreateHandler().Handle(
+            new ValidateAccessCodeCommand(dto), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+    }
+}

--- a/StayWize.UnitTests/Application/Clients/CreateClientCommandHandlerTests.cs
+++ b/StayWize.UnitTests/Application/Clients/CreateClientCommandHandlerTests.cs
@@ -1,0 +1,96 @@
+﻿using FluentAssertions;
+using Moq;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Application.DTOs;
+using StayWize.Application.UseCases.Clients;
+using StayWize.Domain.Entities;
+using StayWize.Services.Encryption;
+using StayWize.Services.ExceptionHandling;
+
+namespace StayWize.UnitTests.Application.Clients;
+
+public class CreateClientCommandHandlerTests
+{
+    private readonly Mock<IClientRepository> _clientRepoMock = new();
+    private readonly Mock<IEncryptionService> _encryptionServiceMock = new();
+
+    private CreateClientCommandHandler CreateHandler() => new(
+        _clientRepoMock.Object,
+        _encryptionServiceMock.Object);
+
+    [Fact]
+    public async Task Handle_ValidData_ShouldCreateClient()
+    {
+        _clientRepoMock.Setup(r => r.GetByEmailAsync(It.IsAny<string>()))
+            .ReturnsAsync((Client?)null);
+        _clientRepoMock.Setup(r => r.GetByDocumentNumberAsync(It.IsAny<string>()))
+            .ReturnsAsync((Client?)null);
+        _encryptionServiceMock.Setup(e => e.Encrypt(It.IsAny<string>()))
+            .Returns("encrypted-doc");
+        _encryptionServiceMock.Setup(e => e.Decrypt(It.IsAny<string>()))
+            .Returns("12345678");
+
+        var dto = new CreateClientDto
+        {
+            FirstName = "Juan",
+            LastName = "Pérez",
+            Email = "juan@test.com",
+            Phone = "123456",
+            DocumentNumber = "12345678"
+        };
+
+        var result = await CreateHandler().Handle(
+            new CreateClientCommand(dto), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.Email.Should().Be("juan@test.com");
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateEmail_ShouldThrowConflictException()
+    {
+        var existingClient = Client.Create("Existing", "Client", "juan@test.com", "123", "99999");
+
+        _clientRepoMock.Setup(r => r.GetByEmailAsync("juan@test.com"))
+            .ReturnsAsync(existingClient);
+
+        var dto = new CreateClientDto
+        {
+            FirstName = "Juan",
+            LastName = "Pérez",
+            Email = "juan@test.com",
+            Phone = "123456",
+            DocumentNumber = "12345678"
+        };
+
+        var action = async () => await CreateHandler().Handle(
+            new CreateClientCommand(dto), CancellationToken.None);
+
+        await action.Should().ThrowAsync<ConflictException>();
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateDocument_ShouldThrowConflictException()
+    {
+        var existingClient = Client.Create("Existing", "Client", "other@test.com", "123", "12345678");
+
+        _clientRepoMock.Setup(r => r.GetByEmailAsync(It.IsAny<string>()))
+            .ReturnsAsync((Client?)null);
+        _clientRepoMock.Setup(r => r.GetByDocumentNumberAsync("12345678"))
+            .ReturnsAsync(existingClient);
+
+        var dto = new CreateClientDto
+        {
+            FirstName = "Juan",
+            LastName = "Pérez",
+            Email = "juan@test.com",
+            Phone = "123456",
+            DocumentNumber = "12345678"
+        };
+
+        var action = async () => await CreateHandler().Handle(
+            new CreateClientCommand(dto), CancellationToken.None);
+
+        await action.Should().ThrowAsync<ConflictException>();
+    }
+}

--- a/StayWize.UnitTests/Application/Reservations/CancelReservationCommandHandlerTests.cs
+++ b/StayWize.UnitTests/Application/Reservations/CancelReservationCommandHandlerTests.cs
@@ -1,0 +1,45 @@
+﻿using FluentAssertions;
+using Moq;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Application.UseCases.Reservations;
+using StayWize.Domain.Entities;
+using StayWize.Domain.Enums;
+
+namespace StayWize.UnitTests.Application.Reservations;
+
+public class CancelReservationCommandHandlerTests
+{
+    private readonly Mock<IReservationRepository> _reservationRepoMock = new();
+
+    [Fact]
+    public async Task Handle_ExistingReservation_ShouldCancelReservation()
+    {
+        var reservation = Reservation.Create(
+            Guid.NewGuid(), Guid.NewGuid(),
+            DateTime.UtcNow.AddDays(1),
+            DateTime.UtcNow.AddDays(5), 2);
+
+        _reservationRepoMock.Setup(r => r.GetByIdAsync(reservation.Id))
+            .ReturnsAsync(reservation);
+
+        var handler = new CancelReservationCommandHandler(_reservationRepoMock.Object);
+        var result = await handler.Handle(
+            new CancelReservationCommand(reservation.Id), CancellationToken.None);
+
+        result.Should().BeTrue();
+        reservation.Status.Should().Be(ReservationStatus.Cancelled);
+    }
+
+    [Fact]
+    public async Task Handle_ReservationNotFound_ShouldReturnFalse()
+    {
+        _reservationRepoMock.Setup(r => r.GetByIdAsync(It.IsAny<Guid>()))
+            .ReturnsAsync((Reservation?)null);
+
+        var handler = new CancelReservationCommandHandler(_reservationRepoMock.Object);
+        var result = await handler.Handle(
+            new CancelReservationCommand(Guid.NewGuid()), CancellationToken.None);
+
+        result.Should().BeFalse();
+    }
+}

--- a/StayWize.UnitTests/Application/Reservations/ConfirmReservationCommandHandlerTests.cs
+++ b/StayWize.UnitTests/Application/Reservations/ConfirmReservationCommandHandlerTests.cs
@@ -1,0 +1,60 @@
+﻿using FluentAssertions;
+using Moq;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Application.UseCases.Reservations;
+using StayWize.Domain.Entities;
+using StayWize.Domain.Enums;
+using StayWize.Services.Notifications;
+
+namespace StayWize.UnitTests.Application.Reservations;
+
+public class ConfirmReservationCommandHandlerTests
+{
+    private readonly Mock<IReservationRepository> _reservationRepoMock = new();
+    private readonly Mock<IClientRepository> _clientRepoMock = new();
+    private readonly Mock<IPropertyRepository> _propertyRepoMock = new();
+    private readonly Mock<IEmailService> _emailServiceMock = new();
+
+    private ConfirmReservationCommandHandler CreateHandler() => new(
+        _reservationRepoMock.Object,
+        _clientRepoMock.Object,
+        _propertyRepoMock.Object,
+        _emailServiceMock.Object);
+
+    [Fact]
+    public async Task Handle_ExistingReservation_ShouldConfirmAndSendEmail()
+    {
+        var reservation = Reservation.Create(
+            Guid.NewGuid(), Guid.NewGuid(),
+            DateTime.UtcNow.AddDays(1),
+            DateTime.UtcNow.AddDays(5), 2);
+
+        var client = Client.Create("Juan", "Pérez", "juan@test.com", "123", "12345");
+        var property = Property.Create("Depto", "Av. Test 123", "CABA", "Argentina", 4, Guid.NewGuid());
+
+        _reservationRepoMock.Setup(r => r.GetByIdAsync(reservation.Id))
+            .ReturnsAsync(reservation);
+        _clientRepoMock.Setup(r => r.GetByIdAsync(reservation.ClientId))
+            .ReturnsAsync(client);
+        _propertyRepoMock.Setup(r => r.GetByIdAsync(reservation.PropertyId))
+            .ReturnsAsync(property);
+
+        var result = await CreateHandler().Handle(
+            new ConfirmReservationCommand(reservation.Id), CancellationToken.None);
+
+        result.Should().BeTrue();
+        reservation.Status.Should().Be(ReservationStatus.Confirmed);
+    }
+
+    [Fact]
+    public async Task Handle_ReservationNotFound_ShouldReturnFalse()
+    {
+        _reservationRepoMock.Setup(r => r.GetByIdAsync(It.IsAny<Guid>()))
+            .ReturnsAsync((Reservation?)null);
+
+        var result = await CreateHandler().Handle(
+            new ConfirmReservationCommand(Guid.NewGuid()), CancellationToken.None);
+
+        result.Should().BeFalse();
+    }
+}

--- a/StayWize.UnitTests/Application/Reservations/CreateReservationCommandHandlerTests.cs
+++ b/StayWize.UnitTests/Application/Reservations/CreateReservationCommandHandlerTests.cs
@@ -1,0 +1,128 @@
+﻿using FluentAssertions;
+using Moq;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Application.Common.Services;
+using StayWize.Application.DTOs;
+using StayWize.Application.UseCases.Reservations;
+using StayWize.Domain.Entities;
+using StayWize.Services.ExceptionHandling;
+using StayWize.Services.Logging;
+
+namespace StayWize.UnitTests.Application.Reservations;
+
+public class CreateReservationCommandHandlerTests
+{
+    private readonly Mock<IReservationRepository> _reservationRepoMock = new();
+    private readonly Mock<IPropertyRepository> _propertyRepoMock = new();
+    private readonly Mock<IClientRepository> _clientRepoMock = new();
+    private readonly Mock<ILogService> _logServiceMock = new();
+    private readonly ReservationConcurrencyService _concurrencyService = new();
+
+    private CreateReservationCommandHandler CreateHandler() => new(
+        _reservationRepoMock.Object,
+        _propertyRepoMock.Object,
+        _clientRepoMock.Object,
+        _concurrencyService,
+        _logServiceMock.Object);
+
+    [Fact]
+    public async Task Handle_ValidData_ShouldCreateReservation()
+    {
+        var propertyId = Guid.NewGuid();
+        var clientId = Guid.NewGuid();
+
+        _propertyRepoMock.Setup(r => r.ExistsAsync(propertyId)).ReturnsAsync(true);
+        _clientRepoMock.Setup(r => r.ExistsAsync(clientId)).ReturnsAsync(true);
+        _reservationRepoMock.Setup(r => r.HasOverlapAsync(
+            propertyId, It.IsAny<DateTime>(), It.IsAny<DateTime>())).ReturnsAsync(false);
+
+        var dto = new CreateReservationDto
+        {
+            PropertyId = propertyId,
+            ClientId = clientId,
+            CheckIn = DateTime.UtcNow.AddDays(1),
+            CheckOut = DateTime.UtcNow.AddDays(5),
+            GuestCount = 2
+        };
+
+        var result = await CreateHandler().Handle(
+            new CreateReservationCommand(dto), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.PropertyId.Should().Be(propertyId);
+        result.ClientId.Should().Be(clientId);
+    }
+
+    [Fact]
+    public async Task Handle_PropertyNotFound_ShouldThrowNotFoundException()
+    {
+        var propertyId = Guid.NewGuid();
+        var clientId = Guid.NewGuid();
+
+        _propertyRepoMock.Setup(r => r.ExistsAsync(propertyId)).ReturnsAsync(false);
+
+        var dto = new CreateReservationDto
+        {
+            PropertyId = propertyId,
+            ClientId = clientId,
+            CheckIn = DateTime.UtcNow.AddDays(1),
+            CheckOut = DateTime.UtcNow.AddDays(5),
+            GuestCount = 2
+        };
+
+        var action = async () => await CreateHandler().Handle(
+            new CreateReservationCommand(dto), CancellationToken.None);
+
+        await action.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_ClientNotFound_ShouldThrowNotFoundException()
+    {
+        var propertyId = Guid.NewGuid();
+        var clientId = Guid.NewGuid();
+
+        _propertyRepoMock.Setup(r => r.ExistsAsync(propertyId)).ReturnsAsync(true);
+        _clientRepoMock.Setup(r => r.ExistsAsync(clientId)).ReturnsAsync(false);
+
+        var dto = new CreateReservationDto
+        {
+            PropertyId = propertyId,
+            ClientId = clientId,
+            CheckIn = DateTime.UtcNow.AddDays(1),
+            CheckOut = DateTime.UtcNow.AddDays(5),
+            GuestCount = 2
+        };
+
+        var action = async () => await CreateHandler().Handle(
+            new CreateReservationCommand(dto), CancellationToken.None);
+
+        await action.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_DateOverlap_ShouldThrowConflictException()
+    {
+        var propertyId = Guid.NewGuid();
+        var clientId = Guid.NewGuid();
+
+        _propertyRepoMock.Setup(r => r.ExistsAsync(propertyId)).ReturnsAsync(true);
+        _clientRepoMock.Setup(r => r.ExistsAsync(clientId)).ReturnsAsync(true);
+        _reservationRepoMock.Setup(r => r.HasOverlapAsync(
+            propertyId, It.IsAny<DateTime>(), It.IsAny<DateTime>())).ReturnsAsync(true);
+
+        var dto = new CreateReservationDto
+        {
+            PropertyId = propertyId,
+            ClientId = clientId,
+            CheckIn = DateTime.UtcNow.AddDays(1),
+            CheckOut = DateTime.UtcNow.AddDays(5),
+            GuestCount = 2
+        };
+
+        var action = async () => await CreateHandler().Handle(
+            new CreateReservationCommand(dto), CancellationToken.None);
+
+        await action.Should().ThrowAsync<ConflictException>();
+    }
+}

--- a/StayWize.UnitTests/Domain/AccessCodeTests.cs
+++ b/StayWize.UnitTests/Domain/AccessCodeTests.cs
@@ -1,0 +1,80 @@
+﻿using FluentAssertions;
+using StayWize.Domain.Entities;
+using StayWize.Domain.Enums;
+
+namespace StayWize.UnitTests.Domain;
+
+public class AccessCodeTests
+{
+    private readonly Guid _reservationId = Guid.NewGuid();
+    private readonly DateTime _validFrom = DateTime.UtcNow.AddHours(-1);
+    private readonly DateTime _validTo = DateTime.UtcNow.AddHours(1);
+
+    [Fact]
+    public void Create_ValidData_ShouldCreateAccessCode()
+    {
+        var code = AccessCode.Create(_reservationId, _validFrom, _validTo, AccessCodeType.CheckIn);
+
+        code.Should().NotBeNull();
+        code.ReservationId.Should().Be(_reservationId);
+        code.Status.Should().Be(AccessCodeStatus.Active);
+        code.Code.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Create_ValidToBeforeValidFrom_ShouldThrowArgumentException()
+    {
+        var action = () => AccessCode.Create(
+            _reservationId, _validTo, _validFrom, AccessCodeType.CheckIn);
+
+        action.Should().Throw<ArgumentException>()
+            .WithMessage("*ValidTo*");
+    }
+
+    [Fact]
+    public void IsValid_ActiveAndWithinRange_ShouldReturnTrue()
+    {
+        var code = AccessCode.Create(_reservationId, _validFrom, _validTo, AccessCodeType.CheckIn);
+
+        code.IsValid().Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValid_Revoked_ShouldReturnFalse()
+    {
+        var code = AccessCode.Create(_reservationId, _validFrom, _validTo, AccessCodeType.CheckIn);
+        code.Revoke();
+
+        code.IsValid().Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValid_Expired_ShouldReturnFalse()
+    {
+        var pastFrom = DateTime.UtcNow.AddHours(-2);
+        var pastTo = DateTime.UtcNow.AddHours(-1);
+        var code = AccessCode.Create(_reservationId, pastFrom, pastTo, AccessCodeType.CheckIn);
+
+        code.IsValid().Should().BeFalse();
+    }
+
+    [Fact]
+    public void Revoke_ShouldChangeStatusToRevoked()
+    {
+        var code = AccessCode.Create(_reservationId, _validFrom, _validTo, AccessCodeType.CheckIn);
+
+        code.Revoke();
+
+        code.Status.Should().Be(AccessCodeStatus.Revoked);
+    }
+
+    [Fact]
+    public void MarkAsExpired_ShouldChangeStatusToExpired()
+    {
+        var code = AccessCode.Create(_reservationId, _validFrom, _validTo, AccessCodeType.CheckIn);
+
+        code.MarkAsExpired();
+
+        code.Status.Should().Be(AccessCodeStatus.Expired);
+    }
+}

--- a/StayWize.UnitTests/Domain/BaseEntityTests.cs
+++ b/StayWize.UnitTests/Domain/BaseEntityTests.cs
@@ -1,0 +1,39 @@
+﻿using FluentAssertions;
+using StayWize.Domain.Entities;
+
+namespace StayWize.UnitTests.Domain;
+
+public class BaseEntityTests
+{
+    [Fact]
+    public void SoftDelete_ShouldSetIsDeletedAndMetadata()
+    {
+        var client = Client.Create("Juan", "Pérez", "juan@test.com", "123", "12345");
+
+        client.SoftDelete("admin");
+
+        client.IsDeleted.Should().BeTrue();
+        client.DeletedAt.Should().NotBeNull();
+        client.DeletedBy.Should().Be("admin");
+    }
+
+    [Fact]
+    public void MarkAsUpdated_ShouldSetUpdatedAtAndUpdatedBy()
+    {
+        var client = Client.Create("Juan", "Pérez", "juan@test.com", "123", "12345");
+
+        client.MarkAsUpdated("admin");
+
+        client.UpdatedAt.Should().NotBeNull();
+        client.UpdatedBy.Should().Be("admin");
+    }
+
+    [Fact]
+    public void Create_ShouldGenerateUniqueId()
+    {
+        var client1 = Client.Create("Juan", "Pérez", "juan@test.com", "123", "12345");
+        var client2 = Client.Create("María", "García", "maria@test.com", "456", "67890");
+
+        client1.Id.Should().NotBe(client2.Id);
+    }
+}

--- a/StayWize.UnitTests/Domain/ReservationTests.cs
+++ b/StayWize.UnitTests/Domain/ReservationTests.cs
@@ -1,0 +1,78 @@
+﻿using FluentAssertions;
+using StayWize.Domain.Entities;
+using StayWize.Domain.Enums;
+
+namespace StayWize.UnitTests.Domain;
+
+public class ReservationTests
+{
+    private readonly Guid _propertyId = Guid.NewGuid();
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly DateTime _checkIn = DateTime.UtcNow.AddDays(1);
+    private readonly DateTime _checkOut = DateTime.UtcNow.AddDays(5);
+
+    [Fact]
+    public void Create_ValidData_ShouldCreateReservation()
+    {
+        var reservation = Reservation.Create(_propertyId, _clientId, _checkIn, _checkOut, 2);
+
+        reservation.Should().NotBeNull();
+        reservation.PropertyId.Should().Be(_propertyId);
+        reservation.ClientId.Should().Be(_clientId);
+        reservation.GuestCount.Should().Be(2);
+        reservation.Status.Should().Be(ReservationStatus.Pending);
+    }
+
+    [Fact]
+    public void Create_CheckOutBeforeCheckIn_ShouldThrowArgumentException()
+    {
+        var action = () => Reservation.Create(
+            _propertyId, _clientId,
+            _checkOut, _checkIn, 2);
+
+        action.Should().Throw<ArgumentException>()
+            .WithMessage("*CheckOut*");
+    }
+
+    [Fact]
+    public void Create_ZeroGuestCount_ShouldThrowArgumentException()
+    {
+        var action = () => Reservation.Create(
+            _propertyId, _clientId,
+            _checkIn, _checkOut, 0);
+
+        action.Should().Throw<ArgumentException>()
+            .WithMessage("*huéspedes*");
+    }
+
+    [Fact]
+    public void Confirm_ShouldChangeStatusToConfirmed()
+    {
+        var reservation = Reservation.Create(_propertyId, _clientId, _checkIn, _checkOut, 2);
+
+        reservation.Confirm();
+
+        reservation.Status.Should().Be(ReservationStatus.Confirmed);
+    }
+
+    [Fact]
+    public void Cancel_ShouldChangeStatusToCancelled()
+    {
+        var reservation = Reservation.Create(_propertyId, _clientId, _checkIn, _checkOut, 2);
+
+        reservation.Cancel();
+
+        reservation.Status.Should().Be(ReservationStatus.Cancelled);
+    }
+
+    [Fact]
+    public void AssignHostLocal_ShouldSetHostLocalId()
+    {
+        var reservation = Reservation.Create(_propertyId, _clientId, _checkIn, _checkOut, 2);
+        var hostLocalId = Guid.NewGuid();
+
+        reservation.AssignHostLocal(hostLocalId);
+
+        reservation.HostLocalId.Should().Be(hostLocalId);
+    }
+}

--- a/StayWize.UnitTests/Services/EncryptionServiceTests.cs
+++ b/StayWize.UnitTests/Services/EncryptionServiceTests.cs
@@ -1,0 +1,68 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using StayWize.Services.Encryption;
+
+namespace StayWize.UnitTests.Services;
+
+public class EncryptionServiceTests
+{
+    private readonly IEncryptionService _encryptionService;
+
+    public EncryptionServiceTests()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["EncryptionSettings:SecretKey"] = "test-encryption-key-32-bytes-long!"
+            })
+            .Build();
+
+        _encryptionService = new EncryptionService(config);
+    }
+
+    [Fact]
+    public void Encrypt_ThenDecrypt_ShouldReturnOriginalValue()
+    {
+        var original = "35123456";
+
+        var encrypted = _encryptionService.Encrypt(original);
+        var decrypted = _encryptionService.Decrypt(encrypted);
+
+        decrypted.Should().Be(original);
+    }
+
+    [Fact]
+    public void Encrypt_SameValueTwice_ShouldProduceDifferentResults()
+    {
+        var value = "35123456";
+
+        var encrypted1 = _encryptionService.Encrypt(value);
+        var encrypted2 = _encryptionService.Encrypt(value);
+
+        encrypted1.Should().NotBe(encrypted2);
+    }
+
+    [Fact]
+    public void Encrypt_EmptyString_ShouldReturnEmptyString()
+    {
+        var result = _encryptionService.Encrypt(string.Empty);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Decrypt_EmptyString_ShouldReturnEmptyString()
+    {
+        var result = _encryptionService.Decrypt(string.Empty);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Encrypt_ShouldProduceFormatWithColon()
+    {
+        var encrypted = _encryptionService.Encrypt("test");
+
+        encrypted.Should().Contain(":");
+    }
+}

--- a/StayWize.UnitTests/Services/LocalizationServiceTests.cs
+++ b/StayWize.UnitTests/Services/LocalizationServiceTests.cs
@@ -1,0 +1,79 @@
+﻿using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using StayWize.Services.Localization;
+
+namespace StayWize.UnitTests.Services;
+
+public class LocalizationServiceTests
+{
+    private ILocalizationService CreateService(string? acceptLanguage = null)
+    {
+        var httpContextMock = new Mock<HttpContext>();
+        var requestMock = new Mock<HttpRequest>();
+        var headersMock = new HeaderDictionary();
+
+        if (acceptLanguage is not null)
+            headersMock["Accept-Language"] = acceptLanguage;
+
+        requestMock.Setup(r => r.Headers).Returns(headersMock);
+        httpContextMock.Setup(c => c.Request).Returns(requestMock.Object);
+
+        var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+        httpContextAccessorMock.Setup(a => a.HttpContext).Returns(httpContextMock.Object);
+
+        return new LocalizationService(httpContextAccessorMock.Object);
+    }
+
+    [Fact]
+    public void Get_NoAcceptLanguageHeader_ShouldReturnSpanish()
+    {
+        var service = CreateService();
+
+        var result = service.Get("NotFound", "Propiedad");
+
+        result.Should().Contain("no fue encontrado");
+    }
+
+    [Fact]
+    public void Get_AcceptLanguageEs_ShouldReturnSpanish()
+    {
+        var service = CreateService("es");
+
+        var result = service.Get("NotFound", "Propiedad");
+
+        result.Should().Contain("no fue encontrado");
+    }
+
+    [Fact]
+    public void Get_AcceptLanguageEn_ShouldReturnEnglish()
+    {
+        var service = CreateService("en");
+
+        var result = service.Get("NotFound", "Property");
+
+        result.Should().Contain("was not found");
+    }
+
+    [Fact]
+    public void Get_UnknownKey_ShouldReturnKey()
+    {
+        var service = CreateService();
+
+        var result = service.Get("UnknownKey");
+
+        result.Should().Be("UnknownKey");
+    }
+
+    [Fact]
+    public void Get_ConcurrencyError_EnglishShouldDifferFromSpanish()
+    {
+        var serviceEs = CreateService("es");
+        var serviceEn = CreateService("en");
+
+        var resultEs = serviceEs.Get("ConcurrencyError");
+        var resultEn = serviceEn.Get("ConcurrencyError");
+
+        resultEs.Should().NotBe(resultEn);
+    }
+}

--- a/StayWize.UnitTests/StayWize.UnitTests.csproj
+++ b/StayWize.UnitTests/StayWize.UnitTests.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\StayWize.Domain\StayWize.Domain.csproj" />
+    <ProjectReference Include="..\StayWize.Application\StayWize.Application.csproj" />
+    <ProjectReference Include="..\StayWize.Infrastructure\StayWize.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/StayWize.slnx
+++ b/StayWize.slnx
@@ -9,4 +9,5 @@
   <Project Path="StayWize.Domain/StayWize.Domain.csproj" />
   <Project Path="StayWize.Infrastructure/StayWize.Infrastructure.csproj" />
   <Project Path="StayWize.Services/StayWize.Services.csproj" />
+  <Project Path="StayWize.UnitTests/StayWize.UnitTests.csproj" />
 </Solution>


### PR DESCRIPTION
Se agrega el proyecto StayWize.UnitTests con configuración para xUnit, Moq y FluentAssertions. Se implementan pruebas unitarias para entidades de dominio (AccessCode, Reservation, BaseEntity), servicios (encriptación, localización) y handlers de aplicación (clientes, reservas, códigos de acceso). Estas pruebas mejoran la cobertura y robustez del sistema StayWize.