### PR TITLE
feat: add Access Codes management feature with CRUD operations and UI…

### DIFF
--- a/StayWize.Application/UseCases/AccessCodes/GetAccessCodesByReservationQuery.cs
+++ b/StayWize.Application/UseCases/AccessCodes/GetAccessCodesByReservationQuery.cs
@@ -1,6 +1,7 @@
 ﻿using MediatR;
 using StayWize.Application.Common.Interfaces;
 using StayWize.Application.DTOs;
+using StayWize.Services.Encryption;
 
 namespace StayWize.Application.UseCases.AccessCodes;
 
@@ -11,10 +12,14 @@ public class GetAccessCodesByReservationQueryHandler
     : IRequestHandler<GetAccessCodesByReservationQuery, IEnumerable<AccessCodeDto>>
 {
     private readonly IAccessCodeRepository _repository;
+    private readonly IEncryptionService _encryptionService;
 
-    public GetAccessCodesByReservationQueryHandler(IAccessCodeRepository repository)
+    public GetAccessCodesByReservationQueryHandler(
+        IAccessCodeRepository repository,
+        IEncryptionService encryptionService)
     {
         _repository = repository;
+        _encryptionService = encryptionService;
     }
 
     public async Task<IEnumerable<AccessCodeDto>> Handle(
@@ -27,12 +32,18 @@ public class GetAccessCodesByReservationQueryHandler
         {
             Id = c.Id,
             ReservationId = c.ReservationId,
-            Code = c.Code,
+            Code = TryDecrypt(c.Code),
             ValidFrom = c.ValidFrom,
             ValidTo = c.ValidTo,
             Status = c.Status,
             Type = c.Type,
             CreatedAt = c.CreatedAt
         });
+    }
+
+    private string TryDecrypt(string code)
+    {
+        try { return _encryptionService.Decrypt(code); }
+        catch { return code; }
     }
 }

--- a/StayWize.Web/src/App.tsx
+++ b/StayWize.Web/src/App.tsx
@@ -6,6 +6,7 @@ import { DashboardPage } from './features/dashboard/DashboardPage';
 import { PropertiesPage } from './features/properties/PropertiesPage';
 import { ClientsPage } from './features/clients/ClientsPage';
 import { ReservationsPage } from './features/reservations/ReservationsPage';
+import { AccessCodesPage } from './features/access-codes/AccessCodesPage';
 
 function App() {
   return (
@@ -17,6 +18,16 @@ function App() {
           <ProtectedRoute>
             <MainLayout>
               <PropertiesPage />
+            </MainLayout>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/access-codes"
+        element={
+          <ProtectedRoute>
+            <MainLayout>
+              <AccessCodesPage />
             </MainLayout>
           </ProtectedRoute>
         }

--- a/StayWize.Web/src/features/access-codes/AccessCodesPage.tsx
+++ b/StayWize.Web/src/features/access-codes/AccessCodesPage.tsx
@@ -1,0 +1,184 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { accessCodeService, type AccessCodeStatus } from './accessCodeService';
+import { GenerateAccessCodeModal } from './GenerateAccessCodeModal';
+import { reservationService } from '../reservations/reservationService';
+
+const statusLabel: Record<AccessCodeStatus, string> = {
+  Active: 'Activo',
+  Revoked: 'Revocado',
+  Expired: 'Expirado',
+};
+
+const statusColor: Record<AccessCodeStatus, string> = {
+  Active: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  Revoked: 'bg-red-50 text-red-600 border-red-200',
+  Expired: 'bg-gray-50 text-gray-500 border-gray-200',
+};
+
+function StatusBadge({ status }: { status: AccessCodeStatus }) {
+  return (
+    <span className={`text-xs font-medium px-2 py-0.5 rounded-full border ${statusColor[status]}`}>
+      {statusLabel[status]}
+    </span>
+  );
+}
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString('es-AR', {
+    day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit',
+  });
+}
+
+export function AccessCodesPage() {
+  const queryClient = useQueryClient();
+  const [searchParams] = useSearchParams();
+  const [showModal, setShowModal] = useState(false);
+  const [selectedReservationId, setSelectedReservationId] = useState<string>(
+    searchParams.get('reservationId') ?? ''
+  );
+
+  const { data: reservations } = useQuery({
+    queryKey: ['reservations'],
+    queryFn: reservationService.getAll,
+  });
+
+  const { data: codes, isLoading } = useQuery({
+    queryKey: ['access-codes', selectedReservationId],
+    queryFn: () => accessCodeService.getByReservation(selectedReservationId),
+    enabled: !!selectedReservationId,
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: accessCodeService.revoke,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['access-codes', selectedReservationId] }),
+  });
+
+  const handleRevoke = (id: string) => {
+    if (confirm('¿Revocar este código de acceso?')) revokeMutation.mutate(id);
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-xl font-bold text-slate-800">Códigos de acceso</h1>
+          <p className="text-sm text-gray-500">Gestión de códigos por reserva</p>
+        </div>
+        {selectedReservationId && (
+          <button
+            onClick={() => setShowModal(true)}
+            className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm font-medium"
+          >
+            + Generar código
+          </button>
+        )}
+      </div>
+
+      {/* Selector de reserva */}
+      <div className="bg-white rounded-lg border border-gray-200 p-4 mb-4 shadow-sm">
+        <label className="block text-sm font-medium text-gray-700 mb-1">Seleccioná una reserva</label>
+        <select
+          value={selectedReservationId}
+          onChange={(e) => setSelectedReservationId(e.target.value)}
+          className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="">-- Seleccioná una reserva --</option>
+          {reservations?.map((r) => (
+            <option key={r.id} value={r.id}>
+              {r.propertyName} — {r.clientName} ({new Date(r.checkIn).toLocaleDateString('es-AR')})
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Tabla — desktop */}
+      {selectedReservationId && (
+        <>
+          {isLoading && <div className="text-gray-400 text-sm">Cargando...</div>}
+
+          <div className="hidden md:block bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 text-gray-500 uppercase text-xs border-b border-gray-200">
+                <tr>
+                  <th className="px-4 py-3 text-left">Código</th>
+                  <th className="px-4 py-3 text-left">Tipo</th>
+                  <th className="px-4 py-3 text-left">Válido desde</th>
+                  <th className="px-4 py-3 text-left">Válido hasta</th>
+                  <th className="px-4 py-3 text-left">Estado</th>
+                  <th className="px-4 py-3 text-left">Acciones</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {codes?.map((code) => (
+                  <tr key={code.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3 font-mono font-bold text-slate-800">{code.code}</td>
+                    <td className="px-4 py-3 text-gray-600">{code.type}</td>
+                    <td className="px-4 py-3 text-gray-600">{formatDate(code.validFrom)}</td>
+                    <td className="px-4 py-3 text-gray-600">{formatDate(code.validTo)}</td>
+                    <td className="px-4 py-3"><StatusBadge status={code.status} /></td>
+                    <td className="px-4 py-3">
+                      {code.status === 'Active' && (
+                        <button
+                          onClick={() => handleRevoke(code.id)}
+                          className="text-red-600 hover:underline text-sm"
+                        >
+                          Revocar
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {codes?.length === 0 && (
+              <div className="text-center py-10 text-gray-400 text-sm">
+                No hay códigos para esta reserva.
+              </div>
+            )}
+          </div>
+
+          {/* Cards — mobile */}
+          <div className="md:hidden space-y-3">
+            {codes?.map((code) => (
+              <div key={code.id} className="bg-white rounded-lg border border-gray-200 p-4 shadow-sm">
+                <div className="flex items-start justify-between mb-2">
+                  <span className="font-mono font-bold text-slate-800 text-lg">{code.code}</span>
+                  <StatusBadge status={code.status} />
+                </div>
+                <div className="space-y-1 text-sm text-gray-600">
+                  <p>Tipo: {code.type}</p>
+                  <p>Desde: {formatDate(code.validFrom)}</p>
+                  <p>Hasta: {formatDate(code.validTo)}</p>
+                </div>
+                {code.status === 'Active' && (
+                  <div className="mt-3 pt-3 border-t border-gray-100">
+                    <button
+                      onClick={() => handleRevoke(code.id)}
+                      className="text-red-600 text-sm font-medium"
+                    >
+                      Revocar
+                    </button>
+                  </div>
+                )}
+              </div>
+            ))}
+            {codes?.length === 0 && (
+              <div className="text-center py-10 text-gray-400 text-sm">
+                No hay códigos para esta reserva.
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      {showModal && selectedReservationId && (
+        <GenerateAccessCodeModal
+          reservationId={selectedReservationId}
+          onClose={() => setShowModal(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/StayWize.Web/src/features/access-codes/GenerateAccessCodeModal.tsx
+++ b/StayWize.Web/src/features/access-codes/GenerateAccessCodeModal.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { accessCodeService } from './accessCodeService';
+
+interface Props {
+  reservationId: string;
+  onClose: () => void;
+}
+
+export function GenerateAccessCodeModal({ reservationId, onClose }: Props) {
+  const queryClient = useQueryClient();
+  const [validFrom, setValidFrom] = useState('');
+  const [validTo, setValidTo] = useState('');
+  const [type, setType] = useState(1);
+  const [error, setError] = useState<string | null>(null);
+
+  const generateMutation = useMutation({
+    mutationFn: () => accessCodeService.generate({
+      reservationId,
+      validFrom: new Date(validFrom).toISOString(),
+      validTo: new Date(validTo).toISOString(),
+      type,
+    }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['access-codes', reservationId] });
+      onClose();
+    },
+    onError: (err: any) => {
+      setError(err.response?.data?.message ?? 'Error al generar el código.');
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    generateMutation.mutate();
+  };
+
+return (
+<div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50 p-4 overflow-y-auto">
+  <div className="bg-white rounded-lg shadow-xl w-full sm:max-w-md p-6 my-auto">      <h2 className="text-lg font-bold text-slate-800 mb-4">Generar código de acceso</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Tipo</label>
+          <select
+            value={type}
+            onChange={(e) => setType(Number(e.target.value))}
+            className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value={1}>Check-in</option>
+            <option value={2}>Check-out</option>
+            <option value={3}>General</option>
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Válido desde</label>
+          <input
+            type="datetime-local"
+            value={validFrom}
+            onChange={(e) => setValidFrom(e.target.value)}
+            required
+            className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Válido hasta</label>
+          <input
+            type="datetime-local"
+            value={validTo}
+            onChange={(e) => setValidTo(e.target.value)}
+            required
+            className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md text-sm">
+            {error}
+          </div>
+        )}
+
+        <div className="flex gap-3 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 border border-gray-300 text-gray-700 py-2.5 rounded-md hover:bg-gray-50 text-sm font-medium"
+          >
+            Cancelar
+          </button>
+          <button
+            type="submit"
+            disabled={generateMutation.isPending}
+            className="flex-1 bg-blue-600 text-white py-2.5 rounded-md hover:bg-blue-700 disabled:opacity-50 text-sm font-medium"
+          >
+            {generateMutation.isPending ? 'Generando...' : 'Generar'}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+);
+}

--- a/StayWize.Web/src/features/access-codes/accessCodeService.ts
+++ b/StayWize.Web/src/features/access-codes/accessCodeService.ts
@@ -1,0 +1,56 @@
+import apiClient from '../../api/client';
+
+export type AccessCodeStatus = 'Active' | 'Revoked' | 'Expired';
+export type AccessCodeType = 'CheckIn' | 'CheckOut' | 'General';
+
+const statusMap: Record<number, AccessCodeStatus> = {
+  1: 'Active',
+  2: 'Revoked',
+  3: 'Expired',
+};
+
+const typeMap: Record<number, AccessCodeType> = {
+  1: 'CheckIn',
+  2: 'CheckOut',
+  3: 'General',
+};
+
+export interface AccessCodeDto {
+  id: string;
+  reservationId: string;
+  code: string;
+  validFrom: string;
+  validTo: string;
+  status: AccessCodeStatus;
+  type: AccessCodeType;
+  createdAt: string;
+}
+
+export interface GenerateAccessCodeDto {
+  reservationId: string;
+  validFrom: string;
+  validTo: string;
+  type: number;
+}
+
+export const accessCodeService = {
+    getByReservation: async (reservationId: string): Promise<AccessCodeDto[]> => {
+    const response = await apiClient.get(`/access-codes/reservation/${reservationId}`);
+    return response.data.map((c: any) => ({
+        ...c,
+        status: statusMap[c.status] ?? 'Active',
+        type: typeMap[c.type] ?? 'CheckIn',
+    }));
+    },
+  generate: async (dto: GenerateAccessCodeDto): Promise<AccessCodeDto> => {
+    const response = await apiClient.post('/access-codes', dto);
+    return {
+      ...response.data,
+      status: statusMap[response.data.status] ?? 'Active',
+      type: typeMap[response.data.type] ?? 'CheckIn',
+    };
+  },
+  revoke: async (id: string): Promise<void> => {
+    await apiClient.patch(`/access-codes/${id}/revoke`);
+  },
+};


### PR DESCRIPTION
… components
This pull request introduces a new Access Codes management feature to the StayWize application, allowing users to view, generate, and revoke access codes associated with reservations. It includes backend improvements for secure code handling and a new frontend interface for managing access codes.

**Backend Enhancements:**

* Added dependency on `IEncryptionService` to `GetAccessCodesByReservationQueryHandler` and implemented decryption logic for access codes, ensuring codes are decrypted before being returned to the frontend. [[1]](diffhunk://#diff-2b40a3b71923799eb591cb02ace9eadb004a245c6991df7f0a8c8706b35ce4c9R4) [[2]](diffhunk://#diff-2b40a3b71923799eb591cb02ace9eadb004a245c6991df7f0a8c8706b35ce4c9R15-R22) [[3]](diffhunk://#diff-2b40a3b71923799eb591cb02ace9eadb004a245c6991df7f0a8c8706b35ce4c9L30-R48)

**Frontend Features:**

_Access Codes Page:_

* Created a new `AccessCodesPage` React component to display, filter, and manage access codes by reservation, including UI for listing codes, showing statuses, and revoking active codes.
* Added a route for `/access-codes` in `App.tsx` to make the new page accessible in the application. [[1]](diffhunk://#diff-3f2ce5b440ddd12fd4a54a624edcbfe5d7e309aa57394ee6050ed5889c473481R9) [[2]](diffhunk://#diff-3f2ce5b440ddd12fd4a54a624edcbfe5d7e309aa57394ee6050ed5889c473481R25-R34)

_Code Generation Modal:_

* Implemented `GenerateAccessCodeModal` for generating new access codes, with form validation and feedback, integrated into the Access Codes page.

_Service Layer:_

* Introduced `accessCodeService` for API interaction, including methods to fetch, generate, and revoke access codes, and mapping of status/type values to user-friendly labels.