### PR TITLE
Añadir soporte para IsSelfCheckIn y pruebas relacionadas

### DIFF
--- a/StayWize.Application/UseCases/Properties/GetAllPropertiesQuery.cs
+++ b/StayWize.Application/UseCases/Properties/GetAllPropertiesQuery.cs
@@ -49,6 +49,7 @@ public class GetAllPropertiesQueryHandler
             Country = p.Country,
             MaxGuests = p.MaxGuests,
             IsActive = p.IsActive,
+            IsSelfCheckIn = p.IsSelfCheckIn,
             OwnerId = p.OwnerId,
             CreatedAt = p.CreatedAt,
             UpdatedAt = p.UpdatedAt

--- a/StayWize.IntegrationTests/Properties/OwnershipScopingTests.cs
+++ b/StayWize.IntegrationTests/Properties/OwnershipScopingTests.cs
@@ -1,0 +1,141 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using StayWize.Application.DTOs;
+using StayWize.IntegrationTests.Setup;
+
+namespace StayWize.IntegrationTests.Properties;
+
+public class OwnershipScopingTests : IntegrationTestBase
+{
+    public OwnershipScopingTests(StayWizeWebApplicationFactory factory) : base(factory) { }
+
+    [Fact]
+    public async Task GetAll_AsOwner_ShouldOnlySeeOwnProperties()
+    {
+        // Autenticarse como Owner A y crear una propiedad
+        var ownerAEmail = $"owner-a-{Guid.NewGuid()}@test.com";
+        await SeedUserAsync(ownerAEmail, "Test1234", "Owner");
+
+        var tokenA = await AuthHelper.GetTokenAsync(Client, "Owner", ownerAEmail);
+        AuthHelper.SetBearerToken(Client, tokenA);
+
+        var propA = await CreatePropertyAsync("Propiedad de Owner A");
+
+        // Autenticarse como Owner B y crear una propiedad
+        var ownerBEmail = $"owner-b-{Guid.NewGuid()}@test.com";
+        await SeedUserAsync(ownerBEmail, "Test1234", "Owner");
+
+        var tokenB = await AuthHelper.GetTokenAsync(Client, "Owner", ownerBEmail);
+        AuthHelper.SetBearerToken(Client, tokenB);
+
+        var propB = await CreatePropertyAsync("Propiedad de Owner B");
+
+        // Owner B solo debe ver su propiedad
+        var response = await Client.GetAsync("/api/properties");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var properties = await response.Content.ReadFromJsonAsync<IEnumerable<PropertyDto>>();
+        var ids = properties!.Select(p => p.Id).ToList();
+
+        ids.Should().Contain(propB.Id);
+        ids.Should().NotContain(propA.Id);
+    }
+
+    [Fact]
+    public async Task GetAll_AsAdmin_ShouldSeeAllProperties()
+    {
+        // Crear dos owners con sus propiedades
+        var ownerAEmail = $"owner-a-{Guid.NewGuid()}@test.com";
+        await SeedUserAsync(ownerAEmail, "Test1234", "Owner");
+        var tokenA = await AuthHelper.GetTokenAsync(Client, "Owner", ownerAEmail);
+        AuthHelper.SetBearerToken(Client, tokenA);
+        var propA = await CreatePropertyAsync("Prop A para admin test");
+
+        var ownerBEmail = $"owner-b-{Guid.NewGuid()}@test.com";
+        await SeedUserAsync(ownerBEmail, "Test1234", "Owner");
+        var tokenB = await AuthHelper.GetTokenAsync(Client, "Owner", ownerBEmail);
+        AuthHelper.SetBearerToken(Client, tokenB);
+        var propB = await CreatePropertyAsync("Prop B para admin test");
+
+        // Admin ve ambas
+        await AuthenticateAsync("Admin");
+        var response = await Client.GetAsync("/api/properties");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var properties = await response.Content.ReadFromJsonAsync<IEnumerable<PropertyDto>>();
+        var ids = properties!.Select(p => p.Id).ToList();
+
+        ids.Should().Contain(propA.Id);
+        ids.Should().Contain(propB.Id);
+    }
+
+    [Fact]
+    public async Task GetById_IsSelfCheckIn_ShouldBeReturnedInResponse()
+    {
+        await AuthenticateAsync("Admin");
+
+        var dto = new CreatePropertyDto
+        {
+            Name = "Self CheckIn Test",
+            Address = "Calle 1",
+            City = "BA",
+            Country = "AR",
+            MaxGuests = 4,
+            OwnerId = Guid.NewGuid(),
+            IsSelfCheckIn = true
+        };
+
+        var createResponse = await Client.PostAsJsonAsync("/api/properties", dto);
+        var created = await createResponse.Content.ReadFromJsonAsync<PropertyDto>();
+
+        var response = await Client.GetAsync($"/api/properties/{created!.Id}");
+        var result = await response.Content.ReadFromJsonAsync<PropertyDto>();
+
+        result!.IsSelfCheckIn.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetAll_IsSelfCheckIn_ShouldBeReturnedInList()
+    {
+        await AuthenticateAsync("Admin");
+
+        var dto = new CreatePropertyDto
+        {
+            Name = "Self CheckIn List Test",
+            Address = "Calle 1",
+            City = "BA",
+            Country = "AR",
+            MaxGuests = 4,
+            OwnerId = Guid.NewGuid(),
+            IsSelfCheckIn = true
+        };
+
+        var createResponse = await Client.PostAsJsonAsync("/api/properties", dto);
+        var created = await createResponse.Content.ReadFromJsonAsync<PropertyDto>();
+
+        var listResponse = await Client.GetAsync("/api/properties");
+        var properties = await listResponse.Content.ReadFromJsonAsync<IEnumerable<PropertyDto>>();
+
+        var found = properties!.FirstOrDefault(p => p.Id == created!.Id);
+        found.Should().NotBeNull();
+        found!.IsSelfCheckIn.Should().BeTrue();
+    }
+
+    private async Task<PropertyDto> CreatePropertyAsync(string name = "Test Property")
+    {
+        var dto = new CreatePropertyDto
+        {
+            Name = name,
+            Address = "Av. Test 123",
+            City = "Buenos Aires",
+            Country = "Argentina",
+            MaxGuests = 4,
+            OwnerId = Guid.NewGuid(),
+            IsSelfCheckIn = true
+        };
+
+        var response = await Client.PostAsJsonAsync("/api/properties", dto);
+        return (await response.Content.ReadFromJsonAsync<PropertyDto>())!;
+    }
+}

--- a/StayWize.IntegrationTests/Setup/AuthHelper.cs
+++ b/StayWize.IntegrationTests/Setup/AuthHelper.cs
@@ -25,12 +25,29 @@ public static class AuthHelper
             Role = role
         };
 
-        // Usar el endpoint de seed que solo existe en entorno Testing
-        var response = await client.PostAsJsonAsync("/api/test/seed-user", registerDto);
-        response.EnsureSuccessStatusCode();
+        // Intentar seed; si el usuario ya existe (409), hacer login directamente
+        var seedResponse = await client.PostAsJsonAsync("/api/test/seed-user", registerDto);
 
-        var result = await response.Content.ReadFromJsonAsync<AuthResponseDto>();
-        return result!.Token;
+        if (seedResponse.IsSuccessStatusCode)
+        {
+            var result = await seedResponse.Content.ReadFromJsonAsync<AuthResponseDto>();
+            return result!.Token;
+        }
+
+        if ((int)seedResponse.StatusCode == 409)
+        {
+            var loginResponse = await client.PostAsJsonAsync("/api/auth/login", new LoginDto
+            {
+                Email = email,
+                Password = "Test1234"
+            });
+            loginResponse.EnsureSuccessStatusCode();
+            var loginResult = await loginResponse.Content.ReadFromJsonAsync<AuthResponseDto>();
+            return loginResult!.Token;
+        }
+
+        seedResponse.EnsureSuccessStatusCode(); // lanza con el status real
+        return string.Empty; // unreachable
     }
 
     public static void SetBearerToken(HttpClient client, string token)


### PR DESCRIPTION
Se agregó la propiedad `IsSelfCheckIn` al mapeo en la clase `GetAllPropertiesQueryHandler` para incluir esta información en las respuestas.

Se actualizó el método de autenticación en `AuthHelper` para manejar usuarios existentes (código 409) realizando login directamente si el seed falla.

Se añadieron pruebas de integración en `OwnershipScopingTests.cs` para validar el comportamiento de las propiedades según el rol del usuario y la inclusión de `IsSelfCheckIn` en las respuestas.

Se creó el método auxiliar `CreatePropertyAsync` para facilitar la creación de propiedades en las pruebas.