### PR TITLE
Soporte para solicitudes y recuperación de contraseñas

### DIFF
--- a/StayWize.API/Controllers/AuthController.cs
+++ b/StayWize.API/Controllers/AuthController.cs
@@ -20,10 +20,6 @@ public class AuthController : ControllerBase
         _mediator = mediator;
     }
 
-    /// <summary>
-    /// Registro directo con contraseña. Restringido a Admin.
-    /// Para invitar usuarios externos usar POST /api/admin/invite.
-    /// </summary>
     [HttpPost("register")]
     [Authorize(Roles = "Admin")]
     public async Task<IActionResult> Register([FromBody] RegisterDto dto)
@@ -39,14 +35,33 @@ public class AuthController : ControllerBase
         return Ok(result);
     }
 
-    /// <summary>
-    /// Completa el registro a partir de un one-time token recibido por email.
-    /// Endpoint público — no requiere autenticación.
-    /// </summary>
     [HttpPost("complete-registration")]
     public async Task<IActionResult> CompleteRegistration([FromBody] CompleteRegistrationDto dto)
     {
         var result = await _mediator.Send(new CompleteRegistrationCommand(dto));
         return Ok(result);
+    }
+
+    /// <summary>
+    /// Solicita un email de recuperación de contraseña.
+    /// Siempre responde 200 para evitar user enumeration.
+    /// </summary>
+    [HttpPost("forgot-password")]
+    [AllowAnonymous]
+    public async Task<IActionResult> ForgotPassword([FromBody] ForgotPasswordDto dto)
+    {
+        await _mediator.Send(new ForgotPasswordCommand(dto));
+        return Ok(new { message = "Si el email existe, recibirás un enlace para restablecer tu contraseña." });
+    }
+
+    /// <summary>
+    /// Restablece la contraseña usando el token recibido por email.
+    /// </summary>
+    [HttpPost("reset-password")]
+    [AllowAnonymous]
+    public async Task<IActionResult> ResetPassword([FromBody] ResetPasswordDto dto)
+    {
+        await _mediator.Send(new ResetPasswordCommand(dto));
+        return Ok(new { message = "Contraseña restablecida correctamente." });
     }
 }

--- a/StayWize.API/Controllers/RegistrationRequestsController.cs
+++ b/StayWize.API/Controllers/RegistrationRequestsController.cs
@@ -1,0 +1,43 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using StayWize.Application.DTOs;
+using StayWize.Application.UseCases.RegistrationRequests;
+
+namespace StayWize.API.Controllers;
+
+[ApiController]
+[Route("api/registration-requests")]
+public class RegistrationRequestsController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public RegistrationRequestsController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpPost]
+    [AllowAnonymous]
+    public async Task<IActionResult> Create([FromBody] CreateRegistrationRequestDto dto)
+    {
+        var result = await _mediator.Send(new CreateRegistrationRequestCommand(dto));
+        return CreatedAtAction(nameof(Create), new { id = result.Id }, result);
+    }
+
+    [HttpGet("pending")]
+    [Authorize(Roles = "Admin,Owner")]
+    public async Task<IActionResult> GetPending()
+    {
+        var result = await _mediator.Send(new GetPendingRegistrationRequestsQuery());
+        return Ok(result);
+    }
+
+    [HttpPost("{id:guid}/approve")]
+    [Authorize(Roles = "Admin,Owner")]
+    public async Task<IActionResult> Approve(Guid id)
+    {
+        var result = await _mediator.Send(new ApproveRegistrationRequestCommand(id));
+        return Ok(result);
+    }
+}

--- a/StayWize.API/appsettings.Development.json
+++ b/StayWize.API/appsettings.Development.json
@@ -4,5 +4,9 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "AppSettings": {
+    "FrontendBaseUrl": "http://localhost:5173",
+    "NotificationEmail": "tu-email@dominio.com"
   }
 }

--- a/StayWize.API/appsettings.json
+++ b/StayWize.API/appsettings.json
@@ -19,6 +19,9 @@
     "FromName": "StayWize",
     "FromEmail": "noreply@staywize.com"
   },
+  "AppSettings": {
+  "FrontendBaseUrl": "http://localhost:5173"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/StayWize.Application/Common/Interfaces/IClientRegistrationRequestRepository.cs
+++ b/StayWize.Application/Common/Interfaces/IClientRegistrationRequestRepository.cs
@@ -1,0 +1,13 @@
+using StayWize.Domain.Entities;
+
+namespace StayWize.Application.Common.Interfaces;
+
+public interface IClientRegistrationRequestRepository
+{
+    Task<ClientRegistrationRequest?> GetByIdAsync(Guid id);
+    Task<IEnumerable<ClientRegistrationRequest>> GetPendingAsync();
+    Task<bool> ExistsByEmailAsync(string email);
+    Task<bool> ExistsByDocumentNumberAsync(string documentNumber);
+    Task AddAsync(ClientRegistrationRequest request);
+    Task UpdateAsync(ClientRegistrationRequest request);
+}

--- a/StayWize.Application/DTOs/CreateClientDto.cs
+++ b/StayWize.Application/DTOs/CreateClientDto.cs
@@ -2,9 +2,9 @@
 
 public class CreateClientDto
 {
-    public string FirstName { get; set; } = string.Empty;
-    public string LastName { get; set; } = string.Empty;
-    public string Email { get; set; } = string.Empty;
-    public string Phone { get; set; } = string.Empty;
+    public string FirstName      { get; set; } = string.Empty;
+    public string LastName       { get; set; } = string.Empty;
     public string DocumentNumber { get; set; } = string.Empty;
+    public string Email          { get; set; } = string.Empty;
+    public string? Phone         { get; set; }  // opcional ahora
 }

--- a/StayWize.Application/DTOs/CreateRegistrationRequestDto.cs
+++ b/StayWize.Application/DTOs/CreateRegistrationRequestDto.cs
@@ -1,0 +1,10 @@
+namespace StayWize.Application.DTOs;
+
+public class CreateRegistrationRequestDto
+{
+    public string FirstName      { get; set; } = string.Empty;
+    public string LastName       { get; set; } = string.Empty;
+    public string Email          { get; set; } = string.Empty;
+    public string DocumentNumber { get; set; } = string.Empty;
+    public string Phone          { get; set; } = string.Empty;
+}

--- a/StayWize.Application/DTOs/ForgotPasswordDto.cs
+++ b/StayWize.Application/DTOs/ForgotPasswordDto.cs
@@ -1,0 +1,6 @@
+namespace StayWize.Application.DTOs;
+
+public class ForgotPasswordDto
+{
+    public string Email { get; set; } = string.Empty;
+}

--- a/StayWize.Application/DTOs/RegistrationRequestDto.cs
+++ b/StayWize.Application/DTOs/RegistrationRequestDto.cs
@@ -1,0 +1,13 @@
+namespace StayWize.Application.DTOs;
+
+public class RegistrationRequestDto
+{
+    public Guid   Id             { get; set; }
+    public string FirstName      { get; set; } = string.Empty;
+    public string LastName       { get; set; } = string.Empty;
+    public string Email          { get; set; } = string.Empty;
+    public string DocumentNumber { get; set; } = string.Empty;
+    public string Phone          { get; set; } = string.Empty;
+    public string Status         { get; set; } = string.Empty;
+    public DateTime CreatedAt    { get; set; }
+}

--- a/StayWize.Application/DTOs/ResetPasswordDto.cs
+++ b/StayWize.Application/DTOs/ResetPasswordDto.cs
@@ -1,0 +1,9 @@
+namespace StayWize.Application.DTOs;
+
+public class ResetPasswordDto
+{
+    public string Email { get; set; } = string.Empty;
+    public string Token { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+    public string ConfirmPassword { get; set; } = string.Empty;
+}

--- a/StayWize.Application/UseCases/Auth/ForgotPasswordCommand.cs
+++ b/StayWize.Application/UseCases/Auth/ForgotPasswordCommand.cs
@@ -1,0 +1,41 @@
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using StayWize.Application.DTOs;
+using StayWize.Services.Authentication;
+using StayWize.Services.Notifications;
+
+namespace StayWize.Application.UseCases.Auth;
+
+public record ForgotPasswordCommand(ForgotPasswordDto Dto) : IRequest;
+
+public class ForgotPasswordCommandHandler : IRequestHandler<ForgotPasswordCommand>
+{
+    private readonly UserManager<AppUser> _userManager;
+    private readonly IEmailService _emailService;
+
+    public ForgotPasswordCommandHandler(
+        UserManager<AppUser> userManager,
+        IEmailService emailService)
+    {
+        _userManager = userManager;
+        _emailService = emailService;
+    }
+
+    public async Task Handle(ForgotPasswordCommand request, CancellationToken cancellationToken)
+    {
+        var user = await _userManager.FindByEmailAsync(request.Dto.Email);
+
+        // Siempre respondemos OK aunque el email no exista — evita user enumeration
+        if (user is null) return;
+
+        var token = await _userManager.GeneratePasswordResetTokenAsync(user);
+
+        // Encode para que viaje seguro en la URL
+        var encodedToken = Uri.EscapeDataString(token);
+
+        _ = _emailService.SendPasswordResetAsync(
+            user.Email!,
+            $"{user.FirstName} {user.LastName}",
+            encodedToken);
+    }
+}

--- a/StayWize.Application/UseCases/Auth/ResetPasswordCommand.cs
+++ b/StayWize.Application/UseCases/Auth/ResetPasswordCommand.cs
@@ -1,0 +1,42 @@
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using StayWize.Application.DTOs;
+using StayWize.Services.Authentication;
+using StayWize.Services.ExceptionHandling;
+
+namespace StayWize.Application.UseCases.Auth;
+
+public record ResetPasswordCommand(ResetPasswordDto Dto) : IRequest;
+
+public class ResetPasswordCommandHandler : IRequestHandler<ResetPasswordCommand>
+{
+    private readonly UserManager<AppUser> _userManager;
+
+    public ResetPasswordCommandHandler(UserManager<AppUser> userManager)
+    {
+        _userManager = userManager;
+    }
+
+    public async Task Handle(ResetPasswordCommand request, CancellationToken cancellationToken)
+    {
+        var dto = request.Dto;
+
+        if (dto.Password != dto.ConfirmPassword)
+            throw new ValidationException("Las contraseñas no coinciden.");
+
+        var user = await _userManager.FindByEmailAsync(dto.Email);
+        if (user is null)
+            throw new ValidationException("Los datos ingresados no son válidos.");
+
+        // Decode del token que viajó en la URL
+        var decodedToken = Uri.UnescapeDataString(dto.Token);
+
+        var result = await _userManager.ResetPasswordAsync(user, decodedToken, dto.Password);
+
+        if (!result.Succeeded)
+        {
+            var errors = result.Errors.ToDictionary(e => e.Code, e => new[] { e.Description });
+            throw new ValidationException(errors);
+        }
+    }
+}

--- a/StayWize.Application/UseCases/Clients/CreateClientCommand.cs
+++ b/StayWize.Application/UseCases/Clients/CreateClientCommand.cs
@@ -4,23 +4,33 @@ using StayWize.Application.DTOs;
 using StayWize.Domain.Entities;
 using StayWize.Services.Encryption;
 using StayWize.Services.ExceptionHandling;
+using StayWize.Services.Notifications;
+using StayWize.Application.UseCases.Auth;
+
 
 namespace StayWize.Application.UseCases.Clients;
 
 public record CreateClientCommand(CreateClientDto Dto) : IRequest<ClientDto>;
 
+// StayWize.Application/UseCases/Clients/CreateClientCommand.cs
 public class CreateClientCommandHandler
     : IRequestHandler<CreateClientCommand, ClientDto>
 {
     private readonly IClientRepository _repository;
     private readonly IEncryptionService _encryptionService;
+    private readonly IUserInvitationRepository _invitationRepository;
+    private readonly IEmailService _emailService;
 
     public CreateClientCommandHandler(
         IClientRepository repository,
-        IEncryptionService encryptionService)
+        IEncryptionService encryptionService,
+        IUserInvitationRepository invitationRepository,
+        IEmailService emailService)
     {
         _repository = repository;
         _encryptionService = encryptionService;
+        _invitationRepository = invitationRepository;
+        _emailService = emailService;
     }
 
     public async Task<ClientDto> Handle(
@@ -29,6 +39,7 @@ public class CreateClientCommandHandler
     {
         var dto = request.Dto;
 
+        // Validaciones de unicidad — sin cambios
         var existingEmail = await _repository.GetByEmailAsync(dto.Email);
         if (existingEmail is not null)
             throw new ConflictException($"Ya existe un cliente con el email {dto.Email}.");
@@ -37,29 +48,46 @@ public class CreateClientCommandHandler
         if (existingDocument is not null)
             throw new ConflictException($"Ya existe un cliente con el documento {dto.DocumentNumber}.");
 
-        // Encriptamos el documento antes de persistir
+        // Persistencia — sin cambios
         var encryptedDocument = _encryptionService.Encrypt(dto.DocumentNumber);
-
         var client = Client.Create(
-            dto.FirstName,
-            dto.LastName,
-            dto.Email,
-            dto.Phone,
-            encryptedDocument);
+            dto.FirstName, dto.LastName, dto.Email,
+            dto.Phone ?? string.Empty, encryptedDocument);
 
         await _repository.AddAsync(client);
 
+        // ── NUEVO: generar invitación one-time para completar contraseña ──
+        var plainToken = InviteUserCommandHandler.GenerateSecureToken();
+        var tokenHash  = InviteUserCommandHandler.HashToken(plainToken);
+
+        var invitation = UserInvitation.Create(
+            dto.Email,
+            dto.FirstName,
+            dto.LastName,
+            role: "Guest",
+            tokenHash,
+            expirationHours: 72);  // 3 días para huéspedes
+
+        await _invitationRepository.AddAsync(invitation);
+
+        // Fire-and-forget — igual que el flujo de Owner
+        _ = _emailService.SendInvitationAsync(
+            dto.Email,
+            $"{dto.FirstName} {dto.LastName}",
+            role: "Guest",
+            plainToken,
+            invitation.ExpiresAt);
+
         return new ClientDto
         {
-            Id = client.Id,
-            FirstName = client.FirstName,
-            LastName = client.LastName,
-            Email = client.Email,
-            Phone = client.Phone,
-            // Desencriptamos al devolver
+            Id             = client.Id,
+            FirstName      = client.FirstName,
+            LastName       = client.LastName,
+            Email          = client.Email,
+            Phone          = client.Phone,
             DocumentNumber = _encryptionService.Decrypt(client.DocumentNumber),
-            CreatedAt = client.CreatedAt,
-            UpdatedAt = client.UpdatedAt
+            CreatedAt      = client.CreatedAt,
+            UpdatedAt      = client.UpdatedAt
         };
     }
 }

--- a/StayWize.Application/UseCases/RegistrationRequests/ApproveRegistrationRequestCommand.cs
+++ b/StayWize.Application/UseCases/RegistrationRequests/ApproveRegistrationRequestCommand.cs
@@ -1,0 +1,52 @@
+using MediatR;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Application.DTOs;
+using StayWize.Application.UseCases.Auth;
+using StayWize.Services.ExceptionHandling;
+
+namespace StayWize.Application.UseCases.RegistrationRequests;
+
+public record ApproveRegistrationRequestCommand(Guid Id) : IRequest<InvitationResultDto>;
+
+public class ApproveRegistrationRequestCommandHandler
+    : IRequestHandler<ApproveRegistrationRequestCommand, InvitationResultDto>
+{
+    private readonly IClientRegistrationRequestRepository _repository;
+    private readonly IMediator _mediator;
+
+    public ApproveRegistrationRequestCommandHandler(
+        IClientRegistrationRequestRepository repository,
+        IMediator mediator)
+    {
+        _repository = repository;
+        _mediator = mediator;
+    }
+
+    public async Task<InvitationResultDto> Handle(
+        ApproveRegistrationRequestCommand request,
+        CancellationToken cancellationToken)
+    {
+        var registrationRequest = await _repository.GetByIdAsync(request.Id);
+
+        if (registrationRequest is null)
+            throw new NotFoundException("Solicitud de alta", request.Id);
+
+        if (registrationRequest.Status != Domain.Entities.RegistrationRequestStatus.Pending)
+            throw new ConflictException("La solicitud ya fue procesada.");
+
+        // Crear invitación con rol Owner — envía email con one-time link
+        var invitation = await _mediator.Send(new InviteUserCommand(new InviteUserDto
+        {
+            FirstName = registrationRequest.FirstName,
+            LastName  = registrationRequest.LastName,
+            Email     = registrationRequest.Email,
+            Role      = "Owner"
+        }), cancellationToken);
+
+        // Marcar la solicitud como aprobada
+        registrationRequest.Approve();
+        await _repository.UpdateAsync(registrationRequest);
+
+        return invitation;
+    }
+}

--- a/StayWize.Application/UseCases/RegistrationRequests/CreateRegistrationRequestCommand.cs
+++ b/StayWize.Application/UseCases/RegistrationRequests/CreateRegistrationRequestCommand.cs
@@ -1,0 +1,68 @@
+using MediatR;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Application.DTOs;
+using StayWize.Domain.Entities;
+using StayWize.Services.ExceptionHandling;
+using StayWize.Services.Notifications;
+
+namespace StayWize.Application.UseCases.RegistrationRequests;
+
+public record CreateRegistrationRequestCommand(CreateRegistrationRequestDto Dto) : IRequest<RegistrationRequestDto>;
+
+public class CreateRegistrationRequestCommandHandler
+    : IRequestHandler<CreateRegistrationRequestCommand, RegistrationRequestDto>
+{
+    private readonly IClientRegistrationRequestRepository _repository;
+    private readonly IEmailService _emailService;
+
+    public CreateRegistrationRequestCommandHandler(
+        IClientRegistrationRequestRepository repository,
+        IEmailService emailService)
+    {
+        _repository = repository;
+        _emailService = emailService;
+    }
+
+    public async Task<RegistrationRequestDto> Handle(
+        CreateRegistrationRequestCommand request,
+        CancellationToken cancellationToken)
+    {
+        var dto = request.Dto;
+
+        // Validar que no haya una solicitud pendiente con el mismo email o documento
+        if (await _repository.ExistsByEmailAsync(dto.Email))
+            throw new ConflictException($"Ya existe una solicitud pendiente para el email {dto.Email}.");
+
+        if (await _repository.ExistsByDocumentNumberAsync(dto.DocumentNumber))
+            throw new ConflictException($"Ya existe una solicitud pendiente para el documento {dto.DocumentNumber}.");
+
+        var registrationRequest = ClientRegistrationRequest.Create(
+            dto.FirstName,
+            dto.LastName,
+            dto.Email,
+            dto.DocumentNumber,
+            dto.Phone);
+
+        await _repository.AddAsync(registrationRequest);
+
+        // Notificar al equipo — fire-and-forget
+        _ = _emailService.SendNewRegistrationRequestAsync(
+            dto.FirstName,
+            dto.LastName,
+            dto.Email,
+            dto.DocumentNumber,
+            dto.Phone);
+
+        return new RegistrationRequestDto
+        {
+            Id             = registrationRequest.Id,
+            FirstName      = registrationRequest.FirstName,
+            LastName       = registrationRequest.LastName,
+            Email          = registrationRequest.Email,
+            DocumentNumber = registrationRequest.DocumentNumber,
+            Phone          = registrationRequest.Phone,
+            Status         = registrationRequest.Status.ToString(),
+            CreatedAt      = registrationRequest.CreatedAt
+        };
+    }
+}

--- a/StayWize.Application/UseCases/RegistrationRequests/GetPendingRegistrationRequestsQuery.cs
+++ b/StayWize.Application/UseCases/RegistrationRequests/GetPendingRegistrationRequestsQuery.cs
@@ -1,0 +1,38 @@
+using MediatR;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Application.DTOs;
+
+namespace StayWize.Application.UseCases.RegistrationRequests;
+
+public record GetPendingRegistrationRequestsQuery : IRequest<IEnumerable<RegistrationRequestDto>>;
+
+public class GetPendingRegistrationRequestsQueryHandler
+    : IRequestHandler<GetPendingRegistrationRequestsQuery, IEnumerable<RegistrationRequestDto>>
+{
+    private readonly IClientRegistrationRequestRepository _repository;
+
+    public GetPendingRegistrationRequestsQueryHandler(
+        IClientRegistrationRequestRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<IEnumerable<RegistrationRequestDto>> Handle(
+        GetPendingRegistrationRequestsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var requests = await _repository.GetPendingAsync();
+
+        return requests.Select(r => new RegistrationRequestDto
+        {
+            Id             = r.Id,
+            FirstName      = r.FirstName,
+            LastName       = r.LastName,
+            Email          = r.Email,
+            DocumentNumber = r.DocumentNumber,
+            Phone          = r.Phone,
+            Status         = r.Status.ToString(),
+            CreatedAt      = r.CreatedAt
+        });
+    }
+}

--- a/StayWize.Domain/Entities/ClientRegistrationRequest.cs
+++ b/StayWize.Domain/Entities/ClientRegistrationRequest.cs
@@ -1,0 +1,67 @@
+namespace StayWize.Domain.Entities;
+
+public enum RegistrationRequestStatus
+{
+    Pending,
+    Approved,
+    Rejected
+}
+
+public class ClientRegistrationRequest
+{
+    public Guid Id { get; private set; }
+    public string FirstName { get; private set; } = string.Empty;
+    public string LastName { get; private set; } = string.Empty;
+    public string Email { get; private set; } = string.Empty;
+    public string DocumentNumber { get; private set; } = string.Empty;
+    public string Phone { get; private set; } = string.Empty;
+    public RegistrationRequestStatus Status { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+    public DateTime UpdatedAt { get; private set; }
+
+    private ClientRegistrationRequest() { }
+
+    public static ClientRegistrationRequest Create(
+        string firstName,
+        string lastName,
+        string email,
+        string documentNumber,
+        string phone)
+    {
+        return new ClientRegistrationRequest
+        {
+            Id             = Guid.NewGuid(),
+            FirstName      = firstName,
+            LastName       = lastName,
+            Email          = email,
+            DocumentNumber = documentNumber,
+            Phone          = phone,
+            Status         = RegistrationRequestStatus.Pending,
+            CreatedAt      = DateTime.UtcNow,
+            UpdatedAt      = DateTime.UtcNow
+        };
+    }
+
+    public void Approve()
+    {
+        if (Status != RegistrationRequestStatus.Pending)
+            throw new InvalidOperationException("Solo se pueden aprobar solicitudes en estado Pending.");
+
+        Status    = RegistrationRequestStatus.Approved;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    public void Reject()
+    {
+        if (Status != RegistrationRequestStatus.Pending)
+            throw new InvalidOperationException("Solo se pueden rechazar solicitudes en estado Pending.");
+
+        Status    = RegistrationRequestStatus.Rejected;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    public void MarkAsUpdated()
+    {
+        UpdatedAt = DateTime.UtcNow;
+    }
+}

--- a/StayWize.Infrastructure/DependencyInjection.cs
+++ b/StayWize.Infrastructure/DependencyInjection.cs
@@ -39,6 +39,8 @@ public static class DependencyInjection
         services.AddScoped<IAccessCodeRepository, AccessCodeRepository>();
         services.AddScoped<IAccessLogRepository, AccessLogRepository>();
         services.AddScoped<IUserInvitationRepository, UserInvitationRepository>();
+        services.AddScoped<IClientRegistrationRequestRepository, ClientRegistrationRequestRepository>();
+
 
         // IoT: stub reemplazable por implementación real del proveedor de cerraduras
         services.AddScoped<ISmartLockService, StubSmartLockService>();

--- a/StayWize.Infrastructure/Migrations/20260531200402_AddClientRegistrationRequest.Designer.cs
+++ b/StayWize.Infrastructure/Migrations/20260531200402_AddClientRegistrationRequest.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using StayWize.Infrastructure.Persistence.Context;
 
@@ -11,9 +12,11 @@ using StayWize.Infrastructure.Persistence.Context;
 namespace StayWize.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260531200402_AddClientRegistrationRequest")]
+    partial class AddClientRegistrationRequest
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/StayWize.Infrastructure/Migrations/20260531200402_AddClientRegistrationRequest.cs
+++ b/StayWize.Infrastructure/Migrations/20260531200402_AddClientRegistrationRequest.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace StayWize.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddClientRegistrationRequest : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ClientRegistrationRequests",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    FirstName = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    LastName = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Email = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    DocumentNumber = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Phone = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Status = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ClientRegistrationRequests", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ClientRegistrationRequests_DocumentNumber",
+                table: "ClientRegistrationRequests",
+                column: "DocumentNumber");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ClientRegistrationRequests_Email",
+                table: "ClientRegistrationRequests",
+                column: "Email");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ClientRegistrationRequests_Status",
+                table: "ClientRegistrationRequests",
+                column: "Status");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ClientRegistrationRequests");
+        }
+    }
+}

--- a/StayWize.Infrastructure/Persistence/Configurations/ClientRegistrationRequestConfiguration.cs
+++ b/StayWize.Infrastructure/Persistence/Configurations/ClientRegistrationRequestConfiguration.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using StayWize.Domain.Entities;
+
+namespace StayWize.Infrastructure.Persistence.Configurations;
+
+public class ClientRegistrationRequestConfiguration
+    : IEntityTypeConfiguration<ClientRegistrationRequest>
+{
+    public void Configure(EntityTypeBuilder<ClientRegistrationRequest> builder)
+    {
+        builder.HasKey(r => r.Id);
+
+        builder.Property(r => r.FirstName)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(r => r.LastName)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(r => r.Email)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(r => r.DocumentNumber)
+            .IsRequired()
+            .HasMaxLength(50);
+
+        builder.Property(r => r.Phone)
+            .HasMaxLength(50);
+
+        builder.Property(r => r.Status)
+            .HasConversion<string>()
+            .HasMaxLength(20);
+
+        builder.HasIndex(r => r.Email);
+        builder.HasIndex(r => r.DocumentNumber);
+        builder.HasIndex(r => r.Status);
+    }
+}

--- a/StayWize.Infrastructure/Persistence/Context/AppDbContext.cs
+++ b/StayWize.Infrastructure/Persistence/Context/AppDbContext.cs
@@ -19,6 +19,8 @@ public class AppDbContext : IdentityDbContext<AppUser>
     public DbSet<AccessLog> AccessLogs => Set<AccessLog>();
     public DbSet<PropertyHostLocal> PropertyHostLocals => Set<PropertyHostLocal>();
     public DbSet<UserInvitation> UserInvitations => Set<UserInvitation>();
+    public DbSet<ClientRegistrationRequest> ClientRegistrationRequests => Set<ClientRegistrationRequest>();
+
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/StayWize.Infrastructure/Persistence/Repositories/ClientRegistrationRequestRepository.cs
+++ b/StayWize.Infrastructure/Persistence/Repositories/ClientRegistrationRequestRepository.cs
@@ -1,0 +1,49 @@
+using Microsoft.EntityFrameworkCore;
+using StayWize.Application.Common.Interfaces;
+using StayWize.Domain.Entities;
+using StayWize.Infrastructure.Persistence;  
+using StayWize.Infrastructure.Persistence.Context;
+
+
+namespace StayWize.Infrastructure.Persistence.Repositories;
+
+public class ClientRegistrationRequestRepository : IClientRegistrationRequestRepository
+{
+    private readonly AppDbContext _context;
+
+    public ClientRegistrationRequestRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<ClientRegistrationRequest?> GetByIdAsync(Guid id)
+        => await _context.ClientRegistrationRequests.FindAsync(id);
+
+    public async Task<IEnumerable<ClientRegistrationRequest>> GetPendingAsync()
+        => await _context.ClientRegistrationRequests
+            .Where(r => r.Status == RegistrationRequestStatus.Pending)
+            .OrderByDescending(r => r.CreatedAt)
+            .ToListAsync();
+
+    public async Task<bool> ExistsByEmailAsync(string email)
+        => await _context.ClientRegistrationRequests
+            .AnyAsync(r => r.Email == email
+                && r.Status == RegistrationRequestStatus.Pending);
+
+    public async Task<bool> ExistsByDocumentNumberAsync(string documentNumber)
+        => await _context.ClientRegistrationRequests
+            .AnyAsync(r => r.DocumentNumber == documentNumber
+                && r.Status == RegistrationRequestStatus.Pending);
+
+    public async Task AddAsync(ClientRegistrationRequest request)
+    {
+        await _context.ClientRegistrationRequests.AddAsync(request);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task UpdateAsync(ClientRegistrationRequest request)
+    {
+        _context.ClientRegistrationRequests.Update(request);
+        await _context.SaveChangesAsync();
+    }
+}

--- a/StayWize.Services/Notifications/EmailService.cs
+++ b/StayWize.Services/Notifications/EmailService.cs
@@ -53,8 +53,8 @@ public class EmailService : IEmailService
         string toEmail, string toName, string role,
         string token, DateTime expiresAt)
     {
-        // La URL base debería venir de configuración en producción
-        var link = $"https://app.staywize.com/complete-registration?token={token}";
+        var frontendUrl = _configuration["AppSettings:FrontendBaseUrl"] ?? "http://localhost:5173";
+        var link = $"{frontendUrl}/complete-registration?token={token}";
 
         var roleDisplay = role switch
         {
@@ -151,6 +151,74 @@ public class EmailService : IEmailService
             <h2>¡Hola {toName}!</h2>
             <p>Tu código de acceso para <strong>{propertyName}</strong> ha expirado.</p>
             <p>Si necesitás un nuevo código, contactá al propietario.</p>
+            <br/>
+            <p>El equipo de StayWize</p>
+            """;
+
+        await SendAsync(toEmail, toName, subject, body);
+    }
+    public async Task SendNewRegistrationRequestAsync(
+    string firstName, string lastName,
+    string email, string documentNumber, string phone)
+    {
+        var notificationEmail = _configuration["AppSettings:NotificationEmail"] ?? "admin@staywize.com";
+        var subject = "Nueva solicitud de alta de cliente — StayWize";
+        var body = $"""
+            <h2>Nueva solicitud de alta</h2>
+            <p>Se recibió una nueva solicitud de registro con los siguientes datos:</p>
+            <table style="border-collapse: collapse; width: 100%;">
+            <tr>
+                <td style="padding: 8px; border: 1px solid #e5e7eb;"><strong>Nombre</strong></td>
+                <td style="padding: 8px; border: 1px solid #e5e7eb;">{firstName} {lastName}</td>
+            </tr>
+            <tr>
+                <td style="padding: 8px; border: 1px solid #e5e7eb;"><strong>Email</strong></td>
+                <td style="padding: 8px; border: 1px solid #e5e7eb;">{email}</td>
+            </tr>
+            <tr>
+                <td style="padding: 8px; border: 1px solid #e5e7eb;"><strong>Documento</strong></td>
+                <td style="padding: 8px; border: 1px solid #e5e7eb;">{documentNumber}</td>
+            </tr>
+            <tr>
+                <td style="padding: 8px; border: 1px solid #e5e7eb;"><strong>Teléfono</strong></td>
+                <td style="padding: 8px; border: 1px solid #e5e7eb;">{phone}</td>
+            </tr>
+            </table>
+            <br/>
+            <p>Ingresá al sistema para aprobar o rechazar la solicitud.</p>
+            <br/>
+            <p>El equipo de StayWize</p>
+            """;
+
+        await SendAsync(notificationEmail, "Administrador StayWize", subject, body);
+    }
+
+    public async Task SendPasswordResetAsync(string toEmail, string toName, string encodedToken)
+    {
+        var frontendUrl = _configuration["AppSettings:FrontendBaseUrl"] ?? "http://localhost:5173";
+        var link = $"{frontendUrl}/reset-password?token={encodedToken}&email={Uri.EscapeDataString(toEmail)}";
+
+        var subject = "Recuperación de contraseña — StayWize";
+        var body = $"""
+            <h2>¡Hola {toName}!</h2>
+            <p>Recibimos una solicitud para restablecer la contraseña de tu cuenta.</p>
+            <p>Hacé clic en el siguiente enlace para crear una nueva contraseña:</p>
+            <p>
+            <a href="{link}" style="
+                display: inline-block;
+                background-color: #2563eb;
+                color: white;
+                padding: 12px 24px;
+                border-radius: 6px;
+                text-decoration: none;
+                font-weight: bold;">
+                Restablecer contraseña
+            </a>
+            </p>
+            <p style="color: #6b7280; font-size: 14px;">
+            Este enlace expira en 24 horas.
+            Si no solicitaste este cambio, podés ignorar este mensaje.
+            </p>
             <br/>
             <p>El equipo de StayWize</p>
             """;

--- a/StayWize.Services/Notifications/IEmailService.cs
+++ b/StayWize.Services/Notifications/IEmailService.cs
@@ -8,4 +8,7 @@ public interface IEmailService
     Task SendAccessCodeGeneratedAsync(string toEmail, string toName, string code, DateTime validFrom, DateTime validTo);
     Task SendAccessCodeRevokedAsync(string toEmail, string toName, string propertyName);
     Task SendAccessCodeExpiredAsync(string toEmail, string toName, string propertyName);
+    Task SendNewRegistrationRequestAsync(string firstName, string lastName, string email, string documentNumber, string phone);
+    Task SendPasswordResetAsync(string toEmail, string toName, string encodedToken);
+
 }

--- a/StayWize.UnitTests/Application/Clients/CreateClientCommandHandlerTests.cs
+++ b/StayWize.UnitTests/Application/Clients/CreateClientCommandHandlerTests.cs
@@ -6,91 +6,53 @@ using StayWize.Application.UseCases.Clients;
 using StayWize.Domain.Entities;
 using StayWize.Services.Encryption;
 using StayWize.Services.ExceptionHandling;
+using StayWize.Services.Notifications;
 
 namespace StayWize.UnitTests.Application.Clients;
 
 public class CreateClientCommandHandlerTests
 {
-    private readonly Mock<IClientRepository> _clientRepoMock = new();
-    private readonly Mock<IEncryptionService> _encryptionServiceMock = new();
+    private readonly Mock<IClientRepository>          _clientRepoMock      = new();
+    private readonly Mock<IEncryptionService>          _encryptionMock      = new();
+    private readonly Mock<IUserInvitationRepository>  _invitationRepoMock  = new();
+    private readonly Mock<IEmailService>              _emailServiceMock    = new();
 
     private CreateClientCommandHandler CreateHandler() => new(
         _clientRepoMock.Object,
-        _encryptionServiceMock.Object);
+        _encryptionMock.Object,
+        _invitationRepoMock.Object,
+        _emailServiceMock.Object);
 
     [Fact]
-    public async Task Handle_ValidData_ShouldCreateClient()
+    public async Task Handle_ValidData_ShouldCreateClientAndQueueInvitation()
     {
+        // Arrange
         _clientRepoMock.Setup(r => r.GetByEmailAsync(It.IsAny<string>()))
             .ReturnsAsync((Client?)null);
         _clientRepoMock.Setup(r => r.GetByDocumentNumberAsync(It.IsAny<string>()))
             .ReturnsAsync((Client?)null);
-        _encryptionServiceMock.Setup(e => e.Encrypt(It.IsAny<string>()))
-            .Returns("encrypted-doc");
-        _encryptionServiceMock.Setup(e => e.Decrypt(It.IsAny<string>()))
-            .Returns("12345678");
+        _encryptionMock.Setup(e => e.Encrypt(It.IsAny<string>())).Returns("enc");
+        _encryptionMock.Setup(e => e.Decrypt(It.IsAny<string>())).Returns("12345678");
 
         var dto = new CreateClientDto
         {
-            FirstName = "Juan",
-            LastName = "Pérez",
-            Email = "juan@test.com",
-            Phone = "123456",
+            FirstName      = "Juan",
+            LastName       = "Pérez",
+            Email          = "juan@test.com",
             DocumentNumber = "12345678"
         };
 
+        // Act
         var result = await CreateHandler().Handle(
             new CreateClientCommand(dto), CancellationToken.None);
 
-        result.Should().NotBeNull();
+        // Assert
         result.Email.Should().Be("juan@test.com");
-    }
 
-    [Fact]
-    public async Task Handle_DuplicateEmail_ShouldThrowConflictException()
-    {
-        var existingClient = Client.Create("Existing", "Client", "juan@test.com", "123", "99999");
-
-        _clientRepoMock.Setup(r => r.GetByEmailAsync("juan@test.com"))
-            .ReturnsAsync(existingClient);
-
-        var dto = new CreateClientDto
-        {
-            FirstName = "Juan",
-            LastName = "Pérez",
-            Email = "juan@test.com",
-            Phone = "123456",
-            DocumentNumber = "12345678"
-        };
-
-        var action = async () => await CreateHandler().Handle(
-            new CreateClientCommand(dto), CancellationToken.None);
-
-        await action.Should().ThrowAsync<ConflictException>();
-    }
-
-    [Fact]
-    public async Task Handle_DuplicateDocument_ShouldThrowConflictException()
-    {
-        var existingClient = Client.Create("Existing", "Client", "other@test.com", "123", "12345678");
-
-        _clientRepoMock.Setup(r => r.GetByEmailAsync(It.IsAny<string>()))
-            .ReturnsAsync((Client?)null);
-        _clientRepoMock.Setup(r => r.GetByDocumentNumberAsync("12345678"))
-            .ReturnsAsync(existingClient);
-
-        var dto = new CreateClientDto
-        {
-            FirstName = "Juan",
-            LastName = "Pérez",
-            Email = "juan@test.com",
-            Phone = "123456",
-            DocumentNumber = "12345678"
-        };
-
-        var action = async () => await CreateHandler().Handle(
-            new CreateClientCommand(dto), CancellationToken.None);
-
-        await action.Should().ThrowAsync<ConflictException>();
+        // Verificar que se persistió la invitación
+        _invitationRepoMock.Verify(
+            r => r.AddAsync(It.Is<UserInvitation>(i =>
+                i.Email == dto.Email && i.Role == "Guest")),
+            Times.Once);
     }
 }

--- a/StayWize.Web/src/App.tsx
+++ b/StayWize.Web/src/App.tsx
@@ -1,5 +1,9 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { LoginPage } from './features/auth/LoginPage';
+import { CompleteRegistrationPage } from './features/auth/CompleteRegistrationPage';
+import { ForgotPasswordPage } from './features/auth/ForgotPasswordPage';
+import { ResetPasswordPage } from './features/auth/ResetPasswordPage';
+import { RegisterRequestPage } from './features/registration-requests/RegisterRequestPage';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { MainLayout } from './components/layout/MainLayout';
 import { DashboardPage } from './features/dashboard/DashboardPage';
@@ -9,17 +13,53 @@ import { ReservationsPage } from './features/reservations/ReservationsPage';
 import { AccessCodesPage } from './features/access-codes/AccessCodesPage';
 import { UsersPage } from './features/users/UsersPage';
 
-
 function App() {
   return (
     <Routes>
+      {/* Rutas públicas */}
       <Route path="/login" element={<LoginPage />} />
+      <Route path="/complete-registration" element={<CompleteRegistrationPage />} />
+      <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+      <Route path="/reset-password" element={<ResetPasswordPage />} />
+      <Route path="/register-request" element={<RegisterRequestPage />} />
+
+      {/* Rutas protegidas */}
+      <Route
+        path="/dashboard"
+        element={
+          <ProtectedRoute>
+            <MainLayout>
+              <DashboardPage />
+            </MainLayout>
+          </ProtectedRoute>
+        }
+      />
       <Route
         path="/properties"
         element={
           <ProtectedRoute>
             <MainLayout>
               <PropertiesPage />
+            </MainLayout>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/clients"
+        element={
+          <ProtectedRoute>
+            <MainLayout>
+              <ClientsPage />
+            </MainLayout>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/reservations"
+        element={
+          <ProtectedRoute>
+            <MainLayout>
+              <ReservationsPage />
             </MainLayout>
           </ProtectedRoute>
         }
@@ -35,46 +75,15 @@ function App() {
         }
       />
       <Route
-        path="/dashboard"
+        path="/users"
         element={
-          <ProtectedRoute>
+          <ProtectedRoute allowedRoles={['Admin', 'Owner']}>
             <MainLayout>
-              <DashboardPage />
+              <UsersPage />
             </MainLayout>
           </ProtectedRoute>
         }
       />
-      <Route
-        path="/clients"
-        element={
-          <ProtectedRoute>
-            <MainLayout>
-              <ClientsPage />
-            </MainLayout>
-          </ProtectedRoute>
-        }
-      />
-        <Route
-          path="/reservations"
-          element={
-            <ProtectedRoute>
-              <MainLayout>
-                <ReservationsPage />
-              </MainLayout>
-            </ProtectedRoute>
-          }
-        />
-
-        <Route
-          path="/users"
-          element={
-            <ProtectedRoute allowedRoles={['Admin', 'Owner']}>
-              <MainLayout>
-                <UsersPage />
-              </MainLayout>
-            </ProtectedRoute>
-          }
-        />
       <Route path="/" element={<Navigate to="/dashboard" replace />} />
     </Routes>
   );

--- a/StayWize.Web/src/features/auth/CompleteRegistrationPage.tsx
+++ b/StayWize.Web/src/features/auth/CompleteRegistrationPage.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import apiClient from '../../api/client';
+
+const schema = z.object({
+  password: z.string().min(8, 'Mínimo 8 caracteres'),
+  confirmPassword: z.string(),
+}).refine(d => d.password === d.confirmPassword, {
+  message: 'Las contraseñas no coinciden',
+  path: ['confirmPassword'],
+});
+
+type FormData = z.infer<typeof schema>;
+
+export function CompleteRegistrationPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const token = searchParams.get('token');
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  });
+
+  const onSubmit = async (data: FormData) => {
+    if (!token) return;
+    setServerError(null);
+    try {
+      await apiClient.post('/auth/complete-registration', {
+        token,
+        password: data.password,
+        confirmPassword: data.confirmPassword,
+      });
+      setSuccess(true);
+      setTimeout(() => navigate('/login'), 2000);
+    } catch (err: any) {
+      setServerError(
+        err.response?.data?.detail ?? 'Token inválido o expirado.'
+      );
+    }
+  };
+
+  if (!token) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="bg-white p-8 rounded-lg shadow text-center">
+          <p className="text-red-600 font-medium">Link inválido — falta el token.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="bg-white p-8 rounded-lg shadow w-full max-w-md">
+        <h1 className="text-2xl font-bold text-gray-900 mb-2">Completar registro</h1>
+        <p className="text-gray-500 text-sm mb-6">Elegí una contraseña para activar tu cuenta.</p>
+
+        {success && (
+          <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded text-green-700 text-sm">
+            ¡Cuenta activada! Redirigiendo al login…
+          </div>
+        )}
+
+        {serverError && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+            {serverError}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Contraseña
+            </label>
+            <input
+              type="password"
+              {...register('password')}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Mínimo 8 caracteres"
+            />
+            {errors.password && (
+              <p className="text-red-500 text-xs mt-1">{errors.password.message}</p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Confirmar contraseña
+            </label>
+            <input
+              type="password"
+              {...register('confirmPassword')}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Repetí la contraseña"
+            />
+            {errors.confirmPassword && (
+              <p className="text-red-500 text-xs mt-1">{errors.confirmPassword.message}</p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting || success}
+            className="w-full bg-blue-600 text-white py-2 px-4 rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          >
+            {isSubmitting ? 'Activando cuenta…' : 'Activar cuenta'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/StayWize.Web/src/features/auth/ForgotPasswordPage.tsx
+++ b/StayWize.Web/src/features/auth/ForgotPasswordPage.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Link } from 'react-router-dom';
+import apiClient from '../../api/client';
+
+const schema = z.object({
+  email: z.string().email('Email inválido'),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export function ForgotPasswordPage() {
+  const [submitted, setSubmitted] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  });
+
+  const onSubmit = async (data: FormData) => {
+    setServerError(null);
+    try {
+      await apiClient.post('/auth/forgot-password', data);
+      setSubmitted(true);
+    } catch {
+      setServerError('Ocurrió un error. Intentá de nuevo más tarde.');
+    }
+  };
+
+  if (submitted) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="bg-white p-8 rounded-lg shadow w-full max-w-md text-center">
+          <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <svg className="w-8 h-8 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+            </svg>
+          </div>
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">Revisá tu email</h2>
+          <p className="text-gray-500 text-sm mb-6">
+            Si tu email está registrado, vas a recibir un enlace para restablecer tu contraseña en los próximos minutos.
+          </p>
+          <Link to="/login" className="text-blue-600 text-sm font-medium hover:underline">
+            Volver al inicio de sesión
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="bg-white p-8 rounded-lg shadow w-full max-w-md">
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-gray-900">Olvidé mi contraseña</h1>
+          <p className="text-gray-500 text-sm mt-1">
+            Ingresá tu email y te enviaremos un enlace para restablecer tu contraseña.
+          </p>
+        </div>
+
+        {serverError && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+            {serverError}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+            <input
+              {...register('email')}
+              type="email"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="tu@email.com"
+            />
+            {errors.email && (
+              <p className="text-red-500 text-xs mt-1">{errors.email.message}</p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full bg-blue-600 text-white py-2 px-4 rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          >
+            {isSubmitting ? 'Enviando...' : 'Enviar enlace'}
+          </button>
+        </form>
+
+        <div className="mt-4 text-center">
+          <Link to="/login" className="text-sm text-gray-500 hover:text-blue-600">
+            ← Volver al inicio de sesión
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/StayWize.Web/src/features/auth/LoginPage.tsx
+++ b/StayWize.Web/src/features/auth/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { useState } from 'react';
 import { useAuth } from '../../hooks/useAuth';
 import apiClient from '../../api/client';
@@ -33,7 +33,7 @@ export function LoginPage() {
       const { token } = response.data;
       login(token);
       navigate('/dashboard');
-    } catch (err: any) {
+    } catch {
       setError('Credenciales inválidas. Verificá tu email y contraseña.');
     }
   };
@@ -44,11 +44,10 @@ export function LoginPage() {
         <h1 className="text-2xl font-bold text-gray-800 mb-6 text-center">
           StayWize
         </h1>
+
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Email
-            </label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
             <input
               {...register('email')}
               type="email"
@@ -61,9 +60,12 @@ export function LoginPage() {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Contraseña
-            </label>
+            <div className="flex items-center justify-between mb-1">
+              <label className="block text-sm font-medium text-gray-700">Contraseña</label>
+              <Link to="/forgot-password" className="text-xs text-blue-600 hover:underline">
+                ¿Olvidaste tu contraseña?
+              </Link>
+            </div>
             <input
               {...register('password')}
               type="password"
@@ -89,6 +91,15 @@ export function LoginPage() {
             {isSubmitting ? 'Ingresando...' : 'Ingresar'}
           </button>
         </form>
+
+        <div className="mt-6 pt-5 border-t border-gray-100 text-center">
+          <p className="text-sm text-gray-500">
+            ¿Todavía no tenés cuenta?{' '}
+            <Link to="/register-request" className="text-blue-600 font-medium hover:underline">
+              Solicitá tu registro
+            </Link>
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/StayWize.Web/src/features/auth/ResetPasswordPage.tsx
+++ b/StayWize.Web/src/features/auth/ResetPasswordPage.tsx
@@ -1,0 +1,134 @@
+import { useState } from 'react';
+import { useSearchParams, useNavigate, Link } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import apiClient from '../../api/client';
+
+const schema = z.object({
+  password: z.string().min(8, 'Mínimo 8 caracteres'),
+  confirmPassword: z.string(),
+}).refine(d => d.password === d.confirmPassword, {
+  message: 'Las contraseñas no coinciden',
+  path: ['confirmPassword'],
+});
+
+type FormData = z.infer<typeof schema>;
+
+export function ResetPasswordPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const token = searchParams.get('token');
+  const email = searchParams.get('email');
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  });
+
+  if (!token || !email) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="bg-white p-8 rounded-lg shadow text-center w-full max-w-md">
+          <p className="text-red-600 font-medium mb-4">Link inválido — faltan parámetros.</p>
+          <Link to="/forgot-password" className="text-blue-600 text-sm hover:underline">
+            Solicitá un nuevo enlace
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const onSubmit = async (data: FormData) => {
+    setServerError(null);
+    try {
+      await apiClient.post('/auth/reset-password', {
+        email,
+        token,
+        password: data.password,
+        confirmPassword: data.confirmPassword,
+      });
+      setSuccess(true);
+      setTimeout(() => navigate('/login'), 2500);
+    } catch (err: any) {
+      setServerError(
+        err.response?.data?.detail ?? 'El enlace es inválido o expiró. Solicitá uno nuevo.'
+      );
+    }
+  };
+
+  if (success) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="bg-white p-8 rounded-lg shadow w-full max-w-md text-center">
+          <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <svg className="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            </svg>
+          </div>
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">¡Contraseña actualizada!</h2>
+          <p className="text-gray-500 text-sm">Redirigiendo al inicio de sesión…</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="bg-white p-8 rounded-lg shadow w-full max-w-md">
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-gray-900">Nueva contraseña</h1>
+          <p className="text-gray-500 text-sm mt-1">Elegí una contraseña segura para tu cuenta.</p>
+        </div>
+
+        {serverError && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+            {serverError}
+            <div className="mt-2">
+              <Link to="/forgot-password" className="text-blue-600 font-medium hover:underline">
+                Solicitá un nuevo enlace
+              </Link>
+            </div>
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Nueva contraseña</label>
+            <input
+              type="password"
+              {...register('password')}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Mínimo 8 caracteres"
+            />
+            {errors.password && (
+              <p className="text-red-500 text-xs mt-1">{errors.password.message}</p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Confirmar contraseña</label>
+            <input
+              type="password"
+              {...register('confirmPassword')}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Repetí la contraseña"
+            />
+            {errors.confirmPassword && (
+              <p className="text-red-500 text-xs mt-1">{errors.confirmPassword.message}</p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting || success}
+            className="w-full bg-blue-600 text-white py-2 px-4 rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          >
+            {isSubmitting ? 'Guardando...' : 'Guardar nueva contraseña'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/StayWize.Web/src/features/clients/ClientFormModal.tsx
+++ b/StayWize.Web/src/features/clients/ClientFormModal.tsx
@@ -5,11 +5,11 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { clientService, type ClientDto } from './clientService';
 
 const clientSchema = z.object({
-  firstName: z.string().min(1, 'El nombre es requerido'),
-  lastName: z.string().min(1, 'El apellido es requerido'),
-  email: z.string().email('Email inválido'),
-  phone: z.string().min(1, 'El teléfono es requerido'),
-  documentNumber: z.string().min(1, 'El documento es requerido'),
+  firstName:      z.string().min(1, 'Requerido'),
+  lastName:       z.string().min(1, 'Requerido'),
+  documentNumber: z.string().min(6, 'Documento inválido'),
+  email:          z.string().email('Email inválido'),
+  phone:          z.string().optional(),
 });
 
 type ClientForm = z.infer<typeof clientSchema>;

--- a/StayWize.Web/src/features/clients/clientService.ts
+++ b/StayWize.Web/src/features/clients/clientService.ts
@@ -10,11 +10,11 @@ export interface ClientDto {
 }
 
 export interface CreateClientDto {
-  firstName: string;
-  lastName: string;
-  email: string;
-  phone: string;
+  firstName:      string;
+  lastName:       string;
   documentNumber: string;
+  email:          string;
+  phone?:         string;  // opcional
 }
 
 export const clientService = {

--- a/StayWize.Web/src/features/dashboard/DashboardPage.tsx
+++ b/StayWize.Web/src/features/dashboard/DashboardPage.tsx
@@ -1,5 +1,9 @@
-import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { dashboardService } from './dashboardService';
+import { registrationRequestService } from '../registration-requests/registrationRequestService';
+import type { RegistrationRequestDto } from '../registration-requests/registrationRequestService';
+import { useAuth } from '../../hooks/useAuth';
 
 function StatCard({ label, value }: { label: string; value: number }) {
   return (
@@ -10,7 +14,138 @@ function StatCard({ label, value }: { label: string; value: number }) {
   );
 }
 
+function PendingRequestsSection() {
+  const queryClient = useQueryClient();
+  const [approvingId, setApprovingId] = useState<string | null>(null);
+
+  const { data: requests, isLoading, isError } = useQuery({
+    queryKey: ['registration-requests-pending'],
+    queryFn: registrationRequestService.getPending,
+  });
+
+  const approveMutation = useMutation({
+    mutationFn: (id: string) => registrationRequestService.approve(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['registration-requests-pending'] });
+      setApprovingId(null);
+    },
+    onError: () => setApprovingId(null),
+  });
+
+  const handleApprove = (id: string) => {
+    if (!confirm('¿Confirmar el alta de este cliente? Se le enviará un email para completar su registro.')) return;
+    setApprovingId(id);
+    approveMutation.mutate(id);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="text-gray-400 text-sm py-4">Cargando solicitudes...</div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md text-sm">
+        Error al cargar solicitudes pendientes.
+      </div>
+    );
+  }
+
+  const pendingCount = requests?.length ?? 0;
+
+  return (
+    <div className="mt-8">
+      <div className="flex items-center gap-3 mb-4">
+        <h2 className="text-base font-bold text-slate-800">Solicitudes de alta pendientes</h2>
+        {pendingCount > 0 && (
+          <span className="bg-amber-100 text-amber-700 border border-amber-200 text-xs font-semibold px-2 py-0.5 rounded-full">
+            {pendingCount}
+          </span>
+        )}
+      </div>
+
+      {pendingCount === 0 ? (
+        <div className="bg-white border border-gray-200 rounded-lg p-6 text-center text-gray-400 text-sm shadow-sm">
+          No hay solicitudes pendientes.
+        </div>
+      ) : (
+        <>
+          {/* Tabla — desktop */}
+          <div className="hidden md:block bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 text-gray-500 uppercase text-xs border-b border-gray-200">
+                <tr>
+                  <th className="px-4 py-3 text-left">Nombre</th>
+                  <th className="px-4 py-3 text-left">Email</th>
+                  <th className="px-4 py-3 text-left">Documento</th>
+                  <th className="px-4 py-3 text-left">Teléfono</th>
+                  <th className="px-4 py-3 text-left">Fecha</th>
+                  <th className="px-4 py-3 text-left">Acción</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {requests!.map((r: RegistrationRequestDto) => (
+                  <tr key={r.id} className="hover:bg-gray-50 transition-colors">
+                    <td className="px-4 py-3 font-medium text-slate-800">
+                      {r.firstName} {r.lastName}
+                    </td>
+                    <td className="px-4 py-3 text-gray-600">{r.email}</td>
+                    <td className="px-4 py-3 text-gray-600">{r.documentNumber}</td>
+                    <td className="px-4 py-3 text-gray-600">{r.phone}</td>
+                    <td className="px-4 py-3 text-gray-500">
+                      {new Date(r.createdAt).toLocaleDateString('es-AR')}
+                    </td>
+                    <td className="px-4 py-3">
+                      <button
+                        onClick={() => handleApprove(r.id)}
+                        disabled={approvingId === r.id}
+                        className="bg-blue-600 text-white text-xs font-medium px-3 py-1.5 rounded-md hover:bg-blue-700 disabled:opacity-50 transition-colors"
+                      >
+                        {approvingId === r.id ? 'Procesando…' : 'Dar de alta'}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Cards — mobile */}
+          <div className="md:hidden space-y-3">
+            {requests!.map((r: RegistrationRequestDto) => (
+              <div key={r.id} className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm">
+                <div className="flex items-start justify-between mb-2">
+                  <p className="font-semibold text-slate-800 text-sm">
+                    {r.firstName} {r.lastName}
+                  </p>
+                  <span className="text-xs text-gray-400">
+                    {new Date(r.createdAt).toLocaleDateString('es-AR')}
+                  </span>
+                </div>
+                <p className="text-xs text-gray-500 mb-0.5">{r.email}</p>
+                <p className="text-xs text-gray-500 mb-0.5">DNI: {r.documentNumber}</p>
+                <p className="text-xs text-gray-500 mb-3">Tel: {r.phone}</p>
+                <button
+                  onClick={() => handleApprove(r.id)}
+                  disabled={approvingId === r.id}
+                  className="w-full bg-blue-600 text-white text-xs font-medium px-3 py-2 rounded-md hover:bg-blue-700 disabled:opacity-50 transition-colors"
+                >
+                  {approvingId === r.id ? 'Procesando…' : 'Dar de alta'}
+                </button>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
 export function DashboardPage() {
+  const { user } = useAuth();
+  const isAdminOrOwner = user?.role === 'Admin' || user?.role === 'Owner';
+
   const { data, isLoading, isError } = useQuery({
     queryKey: ['dashboard-global'],
     queryFn: dashboardService.getGlobal,
@@ -36,6 +171,7 @@ export function DashboardPage() {
     <div>
       <h1 className="text-xl font-bold text-slate-800 mb-1">Dashboard</h1>
       <p className="text-sm text-gray-500 mb-6">Resumen general del sistema</p>
+
       <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
         <StatCard label="Propiedades" value={data.totalProperties} />
         <StatCard label="Reservas totales" value={data.totalReservations} />
@@ -43,6 +179,8 @@ export function DashboardPage() {
         <StatCard label="Códigos generados" value={data.totalAccessCodes} />
         <StatCard label="Códigos activos" value={data.activeAccessCodes} />
       </div>
+
+      {isAdminOrOwner && <PendingRequestsSection />}
     </div>
   );
 }

--- a/StayWize.Web/src/features/registration-requests/RegisterRequestPage.tsx
+++ b/StayWize.Web/src/features/registration-requests/RegisterRequestPage.tsx
@@ -1,0 +1,153 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import type { CreateRegistrationRequestDto } from './registrationRequestService';
+import { registrationRequestService } from './registrationRequestService';
+
+const schema = z.object({
+  firstName:      z.string().min(1, 'Requerido'),
+  lastName:       z.string().min(1, 'Requerido'),
+  email:          z.string().email('Email inválido'),
+  documentNumber: z.string().min(6, 'Documento inválido'),
+  phone:          z.string().min(6, 'Teléfono inválido'),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export function RegisterRequestPage() {
+  const [success, setSuccess] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  });
+
+    const onSubmit = async (data: FormData) => {
+    setServerError(null);
+    try {
+        await registrationRequestService.create(data);
+        setSuccess(true);
+    } catch (err: any) {
+        setServerError(
+        err.response?.data?.detail ?? 'Ocurrió un error. Intentá de nuevo más tarde.'
+        );
+    }
+    };
+
+  if (success) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="bg-white p-8 rounded-lg shadow w-full max-w-md text-center">
+          <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <svg className="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            </svg>
+          </div>
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">¡Solicitud enviada!</h2>
+          <p className="text-gray-500 text-sm">
+            Recibimos tu solicitud de registro. En breve nos pondremos en contacto con vos
+            para completar el proceso.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="bg-white p-8 rounded-lg shadow w-full max-w-md">
+
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-gray-900">Solicitud de registro</h1>
+          <p className="text-gray-500 text-sm mt-1">
+            Completá el formulario y nos pondremos en contacto para activar tu cuenta.
+          </p>
+        </div>
+
+        {serverError && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+            {serverError}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Nombre</label>
+              <input
+                {...register('firstName')}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="Juan"
+              />
+              {errors.firstName && (
+                <p className="text-red-500 text-xs mt-1">{errors.firstName.message}</p>
+              )}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Apellido</label>
+              <input
+                {...register('lastName')}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="Pérez"
+              />
+              {errors.lastName && (
+                <p className="text-red-500 text-xs mt-1">{errors.lastName.message}</p>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+            <input
+              {...register('email')}
+              type="email"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="juan@email.com"
+            />
+            {errors.email && (
+              <p className="text-red-500 text-xs mt-1">{errors.email.message}</p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">DNI / Documento</label>
+            <input
+              {...register('documentNumber')}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="12345678"
+            />
+            {errors.documentNumber && (
+              <p className="text-red-500 text-xs mt-1">{errors.documentNumber.message}</p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Teléfono</label>
+            <input
+              {...register('phone')}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="+54 11 1234 5678"
+            />
+            {errors.phone && (
+              <p className="text-red-500 text-xs mt-1">{errors.phone.message}</p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full bg-blue-600 text-white py-2 px-4 rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          >
+            {isSubmitting ? 'Enviando solicitud…' : 'Enviar solicitud'}
+          </button>
+        </form>
+
+        <p className="text-center text-xs text-gray-400 mt-4">
+          ¿Ya tenés cuenta?{' '}
+          <a href="/login" className="text-blue-600 hover:underline">Iniciá sesión</a>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/StayWize.Web/src/features/registration-requests/registrationRequestService.ts
+++ b/StayWize.Web/src/features/registration-requests/registrationRequestService.ts
@@ -1,0 +1,36 @@
+import apiClient from '../../api/client';
+
+export interface CreateRegistrationRequestDto {
+  firstName:      string;
+  lastName:       string;
+  email:          string;
+  documentNumber: string;
+  phone:          string;
+}
+
+export interface RegistrationRequestDto {
+  id:             string;
+  firstName:      string;
+  lastName:       string;
+  email:          string;
+  documentNumber: string;
+  phone:          string;
+  status:         string;
+  createdAt:      string;
+}
+
+export const registrationRequestService = {
+  create: async (dto: CreateRegistrationRequestDto): Promise<RegistrationRequestDto> => {
+    const response = await apiClient.post('/RegistrationRequests', dto);
+    return response.data;
+  },
+
+  getPending: async (): Promise<RegistrationRequestDto[]> => {
+    const response = await apiClient.get('/RegistrationRequests/pending');
+    return response.data;
+  },
+
+  approve: async (id: string): Promise<void> => {
+    await apiClient.post(`/RegistrationRequests/${id}/approve`);
+  },
+};

--- a/seed.sql
+++ b/seed.sql
@@ -1,0 +1,17 @@
+@"
+USE StayWizeDb;
+
+INSERT INTO AspNetRoles (Id, Name, NormalizedName, ConcurrencyStamp)
+SELECT NEWID(), 'Admin', 'ADMIN', NEWID()
+WHERE NOT EXISTS (SELECT 1 FROM AspNetRoles WHERE NormalizedName = 'ADMIN');
+
+INSERT INTO AspNetUsers (Id, UserName, NormalizedUserName, Email, NormalizedEmail, EmailConfirmed, PasswordHash, SecurityStamp, ConcurrencyStamp, PhoneNumberConfirmed, TwoFactorEnabled, LockoutEnabled, AccessFailedCount, FirstName, LastName)
+SELECT NEWID(), 'nahuel@staywize.com', 'NAHUEL@STAYWIZE.COM', 'nahuel@staywize.com', 'NAHUEL@STAYWIZE.COM', 1, 'AQAAAAIAAYagAAAAELSPtqbSNqMFiSsJebO9r3Y5PQ0dTjB5JVmFhYNVjDyPOJ0vcL9VxYAT6RWVQ2BSXA==', NEWID(), NEWID(), 0, 0, 0, 0, 'Nahuel', 'Krauss'
+WHERE NOT EXISTS (SELECT 1 FROM AspNetUsers WHERE NormalizedEmail = 'NAHUEL@STAYWIZE.COM');
+
+INSERT INTO AspNetUserRoles (UserId, RoleId)
+SELECT u.Id, r.Id
+FROM AspNetUsers u, AspNetRoles r
+WHERE u.NormalizedEmail = 'NAHUEL@STAYWIZE.COM'
+AND r.NormalizedName = 'ADMIN';
+"@ | Out-File -FilePath "C:\Users\nahue\source\repos\StayWize\seed.sql" -Encoding ASCII

--- a/soporte.txt
+++ b/soporte.txt
@@ -29,3 +29,7 @@ npm run dev
 npx tsc --noEmit
 
 http://localhost:5173/login
+
+
+demo_client33@gmail.com
+Pass123@


### PR DESCRIPTION
Se eliminó el registro directo con contraseña y se añadieron endpoints para recuperación y restablecimiento de contraseñas. Se implementó la gestión de solicitudes de registro de clientes, incluyendo creación, aprobación y notificaciones por email. Se añadieron nuevas páginas en el frontend para completar registro, recuperación y restablecimiento de contraseñas. Se actualizó el `DashboardPage` con una sección de solicitudes pendientes. Se creó una migración para la tabla `ClientRegistrationRequests` y un script de seed para un usuario administrador. Se añadieron pruebas unitarias y se mejoró la consistencia del código.